### PR TITLE
Add automatic micromanager discovery for linux

### DIFF
--- a/pymmcore_plus/_util.py
+++ b/pymmcore_plus/_util.py
@@ -26,10 +26,11 @@ def find_micromanager() -> Optional[str]:
     applications = {
         "darwin": Path("/Applications/"),
         "win32": Path("C:/Program Files/"),
+        "linux": Path("/usr/local/lib"),
     }
     try:
         app_path = applications[sys.platform]
-        pth = str(next(app_path.glob("Micro-Manager*")))
+        pth = str(next(app_path.glob("[m,M]icro-[m,M]anager*")))
         logger.debug(f"using MM path found in applications: {pth}")
         return pth
     except KeyError:
@@ -37,5 +38,5 @@ def find_micromanager() -> Optional[str]:
             f"MM autodiscovery not implemented for platform: {sys.platform}"
         )
     except StopIteration:
-        logger.error("could not find micromanager directory")
+        logger.error(f"could not find micromanager directory in {app_path}")
         return None


### PR DESCRIPTION
If you follow the steps in the Docker file for pymmcore (https://github.com/micro-manager/pymmcore/blob/main/Dockerfile)
then you end up with an installation in `/usr/local/lib/micro-manager/`

Also, paths are case senstive on linux hence so search for both capital
and lowercase `m` in the glob.

Finally, added the searched path to the logger if nothing was found in
case people have non-standard install locations.


---

Annoyingly however this won't automatically grab the demo config as the install instructions don't move it to `/usr/local/lib/micro-manager`  so you still need to explicitly locate the path

