### PR TITLE
Set exposure after setting channel in run_mda

### DIFF
--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -118,10 +118,10 @@ class CMMCorePlus(pymmcore.CMMCore):
                 self.setXYPosition(x, y)
             if event.z_pos is not None:
                 self.setZPosition(event.z_pos)
-            if event.exposure is not None:
-                self.setExposure(event.exposure)
             if event.channel is not None:
                 self.setConfig(event.channel.group, event.channel.config)
+            if event.exposure is not None:
+                self.setExposure(event.exposure)
 
             # acquire
             self.waitForSystem()


### PR DESCRIPTION
Depending on user configuration setting the channel can have a side effect of changing the exposure. This then overrides the event exposure. Since the event is a more local config than the channel config it should take precedence for setting the exposure.