### PR TITLE
Add new `configSet` signal.

### DIFF
--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -112,6 +112,14 @@ class CMMCorePlus(pymmcore.CMMCore):
         img = super().getNBeforeLastImageMD(n, md)
         return img, md
 
+    def setConfig(self, groupName: str, configName: str) -> None:
+        """Applies a configuration to a group."""
+        super().setConfig(groupName, configName)
+        # The onConfigGroupChanged callback has some limitations as
+        # discussed in https://github.com/micro-manager/mmCoreAndDevices/issues/25
+        # use the pymmcore-plus configSet signal as a workaround
+        self.events.configSet.emit(groupName, configName)
+
     # config overrides
 
     def getSystemStatePlus(self) -> Configuration:

--- a/pymmcore_plus/core/_signals.py
+++ b/pymmcore_plus/core/_signals.py
@@ -11,6 +11,7 @@ class _CMMCoreSignaler:
     propertyChanged = Signal(str, str, str)
     channelGroupChanged = Signal(str)
     configGroupChanged = Signal(str, str)
+    configSet = Signal(str, str)
     systemConfigurationLoaded = Signal()
     pixelSizeChanged = Signal(float)
     pixelSizeAffineChanged = Signal(float, float, float, float, float, float)


### PR DESCRIPTION
This allows for working around issues with the
`onConfigGroupChanged` signal as discussed at
https://github.com/micro-manager/mmCoreAndDevices/issues/25

Closes: #25 

If this makes sense I'll make a follow PR for napari-micromanager