### PR TITLE
ENH: Check for mda canceled while waiting

### DIFF
--- a/pymmcore_plus/_tests/test_client.py
+++ b/pymmcore_plus/_tests/test_client.py
@@ -65,7 +65,7 @@ def test_mda(qtbot, proxy):
 # test canceling while waiting for the next time point
 def test_mda_cancel(qtbot, proxy: RemoteMMCore):
     mda = MDASequence(time_plan={"interval": 5000, "loops": 3})
-    with qtbot.waitSignals([proxy.events.sequenceStarted]):
+    with qtbot.waitSignal(proxy.events.sequenceStarted):
         proxy.run_mda(mda)
     with qtbot.waitSignals(
         [proxy.events.sequenceFinished, proxy.events.sequenceCanceled], timeout=500

--- a/pymmcore_plus/_tests/test_client.py
+++ b/pymmcore_plus/_tests/test_client.py
@@ -1,5 +1,4 @@
 import os
-import time
 from pathlib import Path
 
 import numpy as np
@@ -64,15 +63,14 @@ def test_mda(qtbot, proxy):
 
 
 # test canceling while waiting for the next time point
-def test_mda_cancel(qtbot, proxy):
-    mda = MDASequence(time_plan={"interval": 5, "loops": 3})
+def test_mda_cancel(qtbot, proxy: RemoteMMCore):
+    mda = MDASequence(time_plan={"interval": 5000, "loops": 3})
     with qtbot.waitSignals([proxy.events.sequenceStarted, proxy.events.frameReady]):
         proxy.run_mda(mda)
-    t0 = time.perf_counter()
-    with qtbot.waitSignals([proxy.events.sequenceFinished], timeout=10000):
+    with qtbot.waitSignals(
+        [proxy.events.sequenceFinished, proxy.events.sequenceCanceled], timeout=500
+    ):
         proxy.cancel()
-    delta_t = time.perf_counter() - t0
-    assert delta_t < 5
 
 
 # TODO: this test may accidentally pass if qtbot is created before this

--- a/pymmcore_plus/_tests/test_client.py
+++ b/pymmcore_plus/_tests/test_client.py
@@ -65,7 +65,7 @@ def test_mda(qtbot, proxy):
 # test canceling while waiting for the next time point
 def test_mda_cancel(qtbot, proxy: RemoteMMCore):
     mda = MDASequence(time_plan={"interval": 5000, "loops": 3})
-    with qtbot.waitSignals([proxy.events.sequenceStarted, proxy.events.frameReady]):
+    with qtbot.waitSignals([proxy.events.sequenceStarted]):
         proxy.run_mda(mda)
     with qtbot.waitSignals(
         [proxy.events.sequenceFinished, proxy.events.sequenceCanceled], timeout=500

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -163,22 +163,47 @@ class CMMCorePlus(pymmcore.CMMCore):
         self._paused = False
         paused_time = 0.0
         t0 = time.perf_counter()  # reference time, in seconds
-        for event in sequence:
-            while self._paused and not self._canceled:
-                paused_time += 0.1  # fixme: be more precise
-                time.sleep(0.1)
+
+        def check_canceled():
             if self._canceled:
                 logger.warning("MDA Canceled: {}", sequence)
                 self.events.sequenceCanceled.emit(sequence)
                 self._canceled = False
+                return True
+            return False
+
+        for event in sequence:
+            while self._paused and not self._canceled:
+                paused_time += 0.1  # fixme: be more precise
+                time.sleep(0.1)
+
+            if check_canceled():
                 break
 
             if event.min_start_time:
                 go_at = event.min_start_time + paused_time
-                # TODO: we need to enter a loop here checking paused and canceled.
+                # We need to enter a loop here checking paused and canceled.
                 # otherwise you'll potentially wait a long time to cancel
-                if go_at > time.perf_counter() - t0:
-                    time.sleep(go_at - (time.perf_counter() - t0))
+                to_go = go_at - (time.perf_counter() - t0)
+                while to_go > 0:
+                    while self._paused and not self._canceled:
+                        paused_time += 0.1  # fixme: be more precise
+                        to_go += 0.1
+                        time.sleep(0.1)
+
+                    if self._canceled:
+                        break
+                    if to_go > 0.5:
+                        time.sleep(0.5)
+                    else:
+                        time.sleep(to_go)
+                    to_go = go_at - (time.perf_counter() - t0)
+
+            # check canceled again in case it was canceled
+            # during the waiting loop
+            if check_canceled():
+                break
+
             logger.info(event)
 
             # prep hardware


### PR DESCRIPTION
Otherwise you can end up waiting for as long as the interval in the
sequence is (easily 10 or 15 minutes)

The test fails locally without the fix and passes with.  Using `time.sleep` instead of `waitSignals` I wasn't able get the ordering of events to work properly - however I'm not sure I'm actually using qtbot correctly here.