### PR TITLE
add getDeviceSchema and getDeviceProperties methods

### DIFF
--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -281,5 +281,5 @@ def test_config_yaml():
 def test_property_schema(core: CMMCorePlus):
     schema = core.getDeviceSchema("Camera")
     assert isinstance(schema, dict)
-    assert schema["title"] == "DCAM"
+    assert schema["title"] == "DCam"
     assert schema["properties"]["AllowMultiROI"] == {"type": "integer", "enum": [0, 1]}

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -276,3 +276,10 @@ def test_config_yaml():
     cfg1 = Configuration.create(input)
     yaml = pytest.importorskip("yaml")
     assert cfg1.yaml() == yaml.safe_dump(input)
+
+
+def test_property_schema(core: CMMCorePlus):
+    schema = core.getDeviceSchema("Camera")
+    assert isinstance(schema, dict)
+    assert schema["title"] == "DCAM"
+    assert schema["properties"]["AllowMultiROI"] == {"type": "integer", "enum": [0, 1]}

--- a/pymmcore_plus/core/_constants.py
+++ b/pymmcore_plus/core/_constants.py
@@ -53,6 +53,9 @@ class PropertyType(IntEnum):
     def to_python(self):
         return {0: None, 1: str, 2: float, 3: int}[self]
 
+    def to_json(self):
+        return {0: "null", 1: "string", 2: "number", 3: "integer"}[self]
+
 
 class ActionType(IntEnum):
     NoAction = 0


### PR DESCRIPTION
Adds two new methods:

`getDeviceProperties` - returns a dict of `{propName: value}` for a given device label

examples:
```py
{
    'Description': 'Demo objective turret driver',
    'HubID': '',
    'Label': 'Nikon 10X S Fluor',
    'Name': 'DObjective',
    'State': '1',
    'Trigger': '-'
}
```


`getDeviceSchema` - returns a schema dict (in json schema format) describing all of the properties (and their allowed values) for a given device_label

example:

```py
{
    'title': 'DObjective',
    'description': 'Demo objective turret',
    'type': 'object',
    'properties': {
        'Description': {'type': 'string', 'readOnly': 'true', 'default': 'Demo objective turret driver'},
        'HubID': {'type': 'string', 'readOnly': 'true', 'default': ''},
        'Label': {
            'type': 'string',
            'enum': [
                'Nikon 10X S Fluor',
                'Nikon 20X Plan Fluor ELWD',
                'Nikon 40X Plan Flueor ELWD',
                'Objective-2',
                'Objective-4',
                'Objective-5'
            ],
            'sequenceable': 'true',
            'sequence_max_length': 10
        },
        'Name': {'type': 'string', 'readOnly': 'true', 'default': 'DObjective'},
        'State': {'type': 'integer', 'sequenceable': 'true', 'sequence_max_length': 10},
        'Trigger': {'type': 'string', 'enum': ['+', '-']}
    }
}
```