### PR TITLE
add setProperty override that emits propertyChanged

### DIFF
--- a/pymmcore_plus/_serialize.py
+++ b/pymmcore_plus/_serialize.py
@@ -19,7 +19,10 @@ SHM_SENT: Deque[SharedMemory] = Deque(maxlen=15)
 def _cleanup():
     for shm in SHM_SENT:
         shm.close()
-        shm.unlink()
+        try:
+            shm.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def ndarray_to_dict(obj: np.ndarray):

--- a/pymmcore_plus/_tests/test_client.py
+++ b/pymmcore_plus/_tests/test_client.py
@@ -13,8 +13,9 @@ from pymmcore_plus.server import DEFAULT_URI
 
 if not os.getenv("MICROMANAGER_PATH"):
     try:
+        sfx = "_win" if os.name == "nt" else "_mac"
         root = Path(pymmcore_plus.__file__).parent.parent
-        mm_path = list(root.glob("**/Micro-Manager-*"))[0]
+        mm_path = list(root.glob(f"**/Micro-Manager-*{sfx}"))[0]
         os.environ["MICROMANAGER_PATH"] = str(mm_path)
     except IndexError:
         raise AssertionError(

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -55,11 +55,13 @@ def test_search_paths(core: CMMCorePlus):
 
 
 def test_cb_exceptions(core: CMMCorePlus, caplog):
-    @core.events.propertyChanged.connect()
+    @core.events.propertyChanged.connect
     def _raze():
         raise ValueError("Boom")
 
-    core.setProperty("Camera", "Binning", 2)
+    # using this to avoid our setProperty override... which would immediately
+    # raise the exception (we want it to be raised deeper)
+    pymmcore.CMMCore.setProperty(core, "Camera", "Binning", 2)
 
     msg = caplog.records[0].message
     assert msg == "Exception occured in MMCorePlus callback 'propertyChanged': Boom"
@@ -283,3 +285,24 @@ def test_property_schema(core: CMMCorePlus):
     assert isinstance(schema, dict)
     assert schema["title"] == "DCam"
     assert schema["properties"]["AllowMultiROI"] == {"type": "boolean"}
+
+
+def test_set_property_events(core: CMMCorePlus):
+    """Test that using setProperty always emits a propertyChanged event."""
+    mock = MagicMock()
+    core.events.propertyChanged.connect(mock)
+    core.setProperty("Camera", "Binning", "2")
+    mock.assert_called_once_with("Camera", "Binning", "2")
+
+    mock.reset_mock()
+    core.setProperty("Camera", "Binning", "1")
+    mock.assert_called_once_with("Camera", "Binning", "1")
+
+    mock.reset_mock()
+    core.setProperty("Camera", "Binning", "1")
+    mock.assert_not_called()  # value didn't change
+
+    # this is not a property that the DemoCamera emits...
+    # so with regular pymmcore, this would not be emitted.
+    core.setProperty("Camera", "AllowMultiROI", "1")
+    mock.assert_called_once_with("Camera", "AllowMultiROI", "1")


### PR DESCRIPTION
related to #28 ... this reimplements `setProperty` to guarantee that an event is emitted if a property is changed using pymmcore.  It can't guarantee that an event will be emitted if it happens internal to the device adapter (and if the device adapter doesn't emit it), but it's a bit better.

@ianhi... now that I understand the issue slightly better what would you think about removing the `configSet` signal that we recently added and instead just reusing the `configGroupChanged` signal?  using a similar pattern to what I did in this PR:

```py
with self.events.configGroupChanged.blocked():
        super().setConfig(groupName, configName)
self.events.configGroupChanged.emit(groupName, configName)
```

is there a specific case where we wanted the native signal and the pymmcore-plus signal to have different names? 