### PR TITLE
Return better config objects

### DIFF
--- a/pymmcore_plus/_tests/test_client.py
+++ b/pymmcore_plus/_tests/test_client.py
@@ -13,8 +13,9 @@ from pymmcore_plus.server import DEFAULT_URI
 
 if not os.getenv("MICROMANAGER_PATH"):
     try:
+        sfx = "_win" if os.name == "nt" else "_mac"
         root = Path(pymmcore_plus.__file__).parent.parent
-        mm_path = list(root.glob("**/Micro-Manager-*"))[0]
+        mm_path = list(root.glob(f"**/Micro-Manager-*{sfx}"))[0]
         os.environ["MICROMANAGER_PATH"] = str(mm_path)
     except IndexError:
         raise AssertionError(

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -236,8 +236,9 @@ def test_md_overrides(core: CMMCorePlus):
 
 
 def test_configuration(core: CMMCorePlus):
-    state = core.getSystemStatePlus()
+    state = core.getSystemState()
     assert isinstance(state, Configuration)
+    assert not isinstance(core.getSystemState(native=True), Configuration)
 
     assert str(state)
 


### PR DESCRIPTION
For the methods that return `Configuration` objects:
```
    "getConfigData",
    "getConfigGroupState",
    "getConfigGroupStateFromCache",
    "getConfigState",
    "getSystemState",
    "getSystemStateCache",
```
this PR will default to returning a `pymmcore_plus.Configuration` which has a number of [conveniences](https://github.com/tlambert03/pymmcore-plus/blob/f8bc9b7736b0a2779ee42d4e4e24a2eff94569bf/pymmcore_plus/core/_config.py#L45-L57) over the native object.  

Because this adds a little overhead, these all also now take a `native=` parameter.  When `native == True`, the native pymmcore.Configuration object will be returned, avoiding the overhead of conversion