### PR TITLE
Fix serialization of Configuration and Metadata objects

### DIFF
--- a/pymmcore_plus/_serialize.py
+++ b/pymmcore_plus/_serialize.py
@@ -1,17 +1,123 @@
 import atexit
 import datetime
+from abc import ABC, abstractmethod
 from multiprocessing.shared_memory import SharedMemory
 from typing import Deque, Generic, TypeVar
 
 import numpy as np
 import pymmcore
 import Pyro5
+import Pyro5.api
 import useq
 from pydantic.datetime_parse import parse_duration
-from Pyro5.api import register_class_to_dict, register_dict_to_class
 
 Pyro5.config.SERIALIZER = "msgpack"
 T = TypeVar("T")
+
+
+class Serializer(ABC, Generic[T]):
+    # define these in subclasses
+
+    @abstractmethod
+    def to_dict(self, obj: T) -> dict:
+        ...
+
+    @abstractmethod
+    def from_dict(self, classname: str, dct: dict) -> T:
+        ...
+
+    # -----------------
+
+    @classmethod
+    @property
+    def type_(cls):
+        return cls.__orig_bases__[0].__args__[0]
+
+    def _to_dict(self, obj: T) -> dict:
+        return {**self.to_dict(obj), "__class__": self.type_key}
+
+    def _from_dict(self, classname: str, d: dict) -> T:
+        d.pop("__class__", None)
+        return self.from_dict(classname, d)
+
+    @classmethod
+    def register(cls):
+        ser = cls()
+        Pyro5.api.register_class_to_dict(ser.type_, ser._to_dict)
+        Pyro5.api.register_dict_to_class(ser.type_key, ser._from_dict)
+
+    @property
+    def type_key(self):
+        return f"{self.type_.__module__}.{self.type_.__name__}"
+
+
+class SerMDASequence(Serializer[useq.MDASequence]):
+    def to_dict(self, obj: useq.MDASequence):
+        return obj.dict()
+
+    def from_dict(self, classname: str, d: dict):
+        return useq.MDASequence.parse_obj(d)
+
+
+class SerMDAEvent(Serializer[useq.MDAEvent]):
+    def to_dict(self, obj: useq.MDAEvent):
+        return obj.dict()
+
+    def from_dict(self, classname: str, d: dict):
+        return useq.MDAEvent.parse_obj(d)
+
+
+class SerTimeDelta(Serializer[datetime.timedelta]):
+    def to_dict(self, obj: datetime.timedelta):
+        return {"val": str(obj)}
+
+    def from_dict(self, classname: str, d: dict):
+        return parse_duration(d["val"])
+
+
+class SerCMMError(Serializer[pymmcore.CMMError]):
+    def to_dict(self, obj: pymmcore.CMMError):
+        try:
+            msg = obj.getMsg()
+        except Exception:  # pragma: no cover
+            msg = ""
+        return {"msg": msg}
+
+    def from_dict(self, classname: str, d: dict):
+        return pymmcore.CMMError(str(d.get("msg")))
+
+
+class SerNDArray(Serializer[np.ndarray]):
+    SHM_SENT: Deque[SharedMemory] = Deque(maxlen=15)
+
+    def to_dict(self, obj: np.ndarray):
+        shm = SharedMemory(create=True, size=obj.nbytes)
+        SerNDArray.SHM_SENT.append(shm)
+        b: np.ndarray = np.ndarray(obj.shape, dtype=obj.dtype, buffer=shm.buf)
+        b[:] = obj[:]
+        return {
+            "shm": shm.name,
+            "shape": obj.shape,
+            "dtype": str(obj.dtype),
+        }
+
+    def from_dict(self, classname: str, d: dict):
+        """convert dict from `ndarray_to_dict` back to np.ndarray"""
+        shm = SharedMemory(name=d["shm"], create=False)
+        array = np.ndarray(d["shape"], dtype=d["dtype"], buffer=shm.buf).copy()
+        shm.close()
+        shm.unlink()
+        return array
+
+
+@atexit.register  # pragma: no cover
+def _cleanup():
+    for shm in SerNDArray.SHM_SENT:
+        shm.close()
+        try:
+            shm.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def remove_shm_from_resource_tracker():
@@ -37,113 +143,6 @@ def remove_shm_from_resource_tracker():
 
     if "shared_memory" in resource_tracker._CLEANUP_FUNCS:
         del resource_tracker._CLEANUP_FUNCS["shared_memory"]
-
-
-class Serializer(Generic[T]):
-    # define these in subclasses
-    type_: T
-
-    def to_dict(obj: T) -> dict:
-        ...
-
-    def from_dict(classname: str, dct: dict) -> T:
-        ...
-
-    # -----------------
-    @classmethod
-    def _to_dict(cls, obj: T) -> dict:
-        return {"__class__": cls.type_key, **cls.to_dict(obj)}
-
-    @classmethod
-    def register(cls):
-        register_class_to_dict(cls.type_, cls._to_dict)
-        register_dict_to_class(cls.type_key, cls.from_dict)
-
-    @classmethod
-    def type_key(cls):
-        return f"{cls.type_.__module__}.{cls.type_.__name__}"
-
-
-class SerMDASequence(Serializer[useq.MDASequence]):
-    type_ = useq.MDASequence
-
-    def to_dict(obj: useq.MDASequence):
-        return obj.dict()
-
-    def from_dict(classname: str, d: dict):
-        return useq.MDASequence.parse_obj(d)
-
-
-class SerMDAEvent(Serializer[useq.MDAEvent]):
-    type_ = useq.MDAEvent
-
-    def to_dict(obj: useq.MDAEvent):
-        return obj.dict()
-
-    def from_dict(classname: str, d: dict):
-        return useq.MDAEvent.parse_obj(d)
-
-
-class SerTimeDelta(Serializer[datetime.timedelta]):
-    type_ = datetime.timedelta
-
-    def to_dict(obj: datetime.timedelta):
-        return {"val": str(obj)}
-
-    def from_dict(classname: str, d: dict):
-        return parse_duration(d.get("val"))
-
-
-class SerCMMError(Serializer[pymmcore.CMMError]):
-    type_ = pymmcore.CMMError
-
-    def to_dict(obj: pymmcore.CMMError):
-        try:
-            msg = obj.getMsg()
-        except Exception:  # pragma: no cover
-            msg = ""
-        return {"msg": msg}
-
-    def from_dict(classname: str, d: dict):
-        return pymmcore.CMMError(str(d.get("msg")))
-
-
-class SerNDArray(Serializer[np.ndarray]):
-    type_ = np.ndarray
-    SHM_SENT: Deque[SharedMemory] = Deque(maxlen=15)
-
-    def to_dict(obj: np.ndarray):
-        shm = SharedMemory(create=True, size=obj.nbytes)
-        SerNDArray.SHM_SENT.append(shm)
-        b = np.ndarray(obj.shape, dtype=obj.dtype, buffer=shm.buf)
-        b[:] = obj[:]
-        return {
-            "shm": shm.name,
-            "shape": obj.shape,
-            "dtype": str(obj.dtype),
-        }
-
-    def from_dict(classname: str, d: dict):
-        """convert dict from `ndarray_to_dict` back to np.ndarray"""
-        shm = SharedMemory(name=d["shm"], create=False)
-        array = np.ndarray(d["shape"], dtype=d["dtype"], buffer=shm.buf).copy()
-        shm.close()
-        shm.unlink()
-        return array
-
-    @classmethod
-    def register(cls):
-        super().register()
-
-
-@atexit.register  # pragma: no cover
-def _cleanup():
-    for shm in SerNDArray.SHM_SENT:
-        shm.close()
-        try:
-            shm.unlink()
-        except FileNotFoundError:
-            pass
 
 
 def register_serializers():

--- a/pymmcore_plus/_serialize.py
+++ b/pymmcore_plus/_serialize.py
@@ -50,7 +50,7 @@ class Serializer(ABC, Generic[T]):
     @classmethod
     @property
     def type_key(cls):
-        return f"{cls.type_().__module__}.{cls.type_.__name__}"
+        return f"{cls.type_().__module__}.{cls.type_().__name__}"
 
 
 class SerMDASequence(Serializer[useq.MDASequence]):

--- a/pymmcore_plus/_serialize.py
+++ b/pymmcore_plus/_serialize.py
@@ -31,7 +31,6 @@ class Serializer(ABC, Generic[T]):
     # -----------------
 
     @classmethod
-    @property
     def type_(cls):
         return cls.__orig_bases__[0].__args__[0]
 
@@ -45,13 +44,13 @@ class Serializer(ABC, Generic[T]):
     @classmethod
     def register(cls):
         ser = cls()
-        Pyro5.api.register_class_to_dict(ser.type_, ser._to_dict)
-        Pyro5.api.register_dict_to_class(ser.type_key, ser._from_dict)
+        Pyro5.api.register_class_to_dict(cls.type_(), ser._to_dict)
+        Pyro5.api.register_dict_to_class(cls.type_key, ser._from_dict)
 
     @classmethod
     @property
     def type_key(cls):
-        return f"{cls.type_.__module__}.{cls.type_.__name__}"
+        return f"{cls.type_().__module__}.{cls.type_.__name__}"
 
 
 class SerMDASequence(Serializer[useq.MDASequence]):

--- a/pymmcore_plus/_serialize.py
+++ b/pymmcore_plus/_serialize.py
@@ -11,6 +11,8 @@ import Pyro5.api
 import useq
 from pydantic.datetime_parse import parse_duration
 
+from .core import Configuration, Metadata
+
 Pyro5.config.SERIALIZER = "msgpack"
 T = TypeVar("T")
 
@@ -65,6 +67,22 @@ class SerMDAEvent(Serializer[useq.MDAEvent]):
 
     def from_dict(self, classname: str, d: dict):
         return useq.MDAEvent.parse_obj(d)
+
+
+class SerConfiguration(Serializer[Configuration]):
+    def to_dict(self, obj: Configuration):
+        return obj.dict()
+
+    def from_dict(self, classname: str, d: dict):
+        return Configuration.create(**d)
+
+
+class SerMetadata(Serializer[Metadata]):
+    def to_dict(self, obj: Metadata):
+        return dict(obj)
+
+    def from_dict(self, classname: str, d: dict):
+        return Metadata(**d)
 
 
 class SerTimeDelta(Serializer[datetime.timedelta]):
@@ -147,8 +165,6 @@ def remove_shm_from_resource_tracker():
 
 def register_serializers():
     remove_shm_from_resource_tracker()
-    SerTimeDelta.register()
-    SerNDArray.register()
-    SerCMMError.register()
-    SerMDASequence.register()
-    SerMDAEvent.register()
+    for i in globals().values():
+        if isinstance(i, type) and issubclass(i, Serializer) and i != Serializer:
+            i.register()

--- a/pymmcore_plus/_serialize.py
+++ b/pymmcore_plus/_serialize.py
@@ -35,7 +35,7 @@ class Serializer(ABC, Generic[T]):
         return cls.__orig_bases__[0].__args__[0]
 
     def _to_dict(self, obj: T) -> dict:
-        return {**self.to_dict(obj), "__class__": self.type_key}
+        return {**self.to_dict(obj), "__class__": self.type_key()}
 
     def _from_dict(self, classname: str, d: dict) -> T:
         d.pop("__class__", None)
@@ -45,10 +45,9 @@ class Serializer(ABC, Generic[T]):
     def register(cls):
         ser = cls()
         Pyro5.api.register_class_to_dict(cls.type_(), ser._to_dict)
-        Pyro5.api.register_dict_to_class(cls.type_key, ser._from_dict)
+        Pyro5.api.register_dict_to_class(cls.type_key(), ser._from_dict)
 
     @classmethod
-    @property
     def type_key(cls):
         return f"{cls.type_().__module__}.{cls.type_().__name__}"
 

--- a/pymmcore_plus/_serialize.py
+++ b/pymmcore_plus/_serialize.py
@@ -48,9 +48,10 @@ class Serializer(ABC, Generic[T]):
         Pyro5.api.register_class_to_dict(ser.type_, ser._to_dict)
         Pyro5.api.register_dict_to_class(ser.type_key, ser._from_dict)
 
+    @classmethod
     @property
-    def type_key(self):
-        return f"{self.type_.__module__}.{self.type_.__name__}"
+    def type_key(cls):
+        return f"{cls.type_.__module__}.{cls.type_.__name__}"
 
 
 class SerMDASequence(Serializer[useq.MDASequence]):

--- a/pymmcore_plus/_tests/test_client.py
+++ b/pymmcore_plus/_tests/test_client.py
@@ -34,6 +34,7 @@ def proxy():
 
 def test_client(proxy):
     assert str(proxy._pyroUri) == DEFAULT_URI
+    proxy.getConfigGroupState("Channel")
 
 
 def test_mda(qtbot, proxy):

--- a/pymmcore_plus/_tests/test_serialize.py
+++ b/pymmcore_plus/_tests/test_serialize.py
@@ -1,30 +1,25 @@
+import operator
+
 import numpy as np
 import pymmcore
 from useq import MDAEvent
 
-from pymmcore_plus._serialize import (
-    CMMError_to_dict,
-    dict_to_CMMError,
-    dict_to_mda_event,
-    dict_to_ndarray,
-    mda_event_to_dict,
-    ndarray_to_dict,
-)
+from pymmcore_plus._serialize import SerCMMError, SerMDAEvent, SerNDArray
+
+
+def _roundtrip(serializer, obj, compare=operator.eq):
+    return compare(serializer.from_dict("", serializer.to_dict(obj)), obj)
 
 
 def test_ndarray():
-    data = np.random.rand(4, 4)
-    d = ndarray_to_dict(data)
-    arr = dict_to_ndarray("", d)
-    np.testing.assert_allclose(data, arr)
+    assert _roundtrip(SerNDArray, np.random.rand(4, 4), np.allclose)
 
 
 def test_cmmerror():
-    err = pymmcore.CMMError("msg", 1)
-    assert dict_to_CMMError("", CMMError_to_dict(err)).getMsg() == err.getMsg()
+    assert _roundtrip(
+        SerCMMError, pymmcore.CMMError("msg", 1), lambda a, b: a.getMsg() == b.getMsg()
+    )
 
 
 def test_mda():
-    event = MDAEvent(exposure=42)
-    d = mda_event_to_dict(event)
-    assert dict_to_mda_event("", d) == event
+    assert _roundtrip(SerMDAEvent, MDAEvent(exposure=42))

--- a/pymmcore_plus/_tests/test_serialize.py
+++ b/pymmcore_plus/_tests/test_serialize.py
@@ -4,11 +4,18 @@ import numpy as np
 import pymmcore
 from useq import MDAEvent
 
-from pymmcore_plus._serialize import SerCMMError, SerMDAEvent, SerNDArray
+from pymmcore_plus import Configuration, Metadata
+from pymmcore_plus._serialize import (
+    SerCMMError,
+    SerConfiguration,
+    SerMDAEvent,
+    SerMetadata,
+    SerNDArray,
+)
 
 
 def _roundtrip(serializer, obj, compare=operator.eq):
-    return compare(serializer.from_dict("", serializer.to_dict(obj)), obj)
+    return compare(serializer().from_dict("", serializer().to_dict(obj)), obj)
 
 
 def test_ndarray():
@@ -23,3 +30,12 @@ def test_cmmerror():
 
 def test_mda():
     assert _roundtrip(SerMDAEvent, MDAEvent(exposure=42))
+
+
+def test_configiration():
+    cfg = Configuration.create({"a": {"a0": "0", "a1": "1"}, "b": {"b0": "10"}})
+    assert _roundtrip(SerConfiguration, cfg)
+
+
+def test_metadata():
+    assert _roundtrip(SerMetadata, Metadata({"a": "1"}))

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -80,7 +80,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         if before != after:
             self.events.propertyChanged.emit(label, propName, after)
 
-    def setDeviceAdapterSearchPaths(self, adapter_paths: ListOrTuple[str]):
+    def setDeviceAdapterSearchPaths(self, adapter_paths: ListOrTuple[str]) -> None:
         # add to PATH as well for dynamic dlls
         if (
             not isinstance(adapter_paths, (list, tuple))
@@ -96,7 +96,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         logger.info(f"setting adapter search paths: {adapter_paths}")
         super().setDeviceAdapterSearchPaths(adapter_paths)
 
-    def loadSystemConfiguration(self, fileName="demo"):
+    def loadSystemConfiguration(self, fileName="demo") -> None:
         if fileName.lower() == "demo":
             if not self._mm_path:
                 raise ValueError(  # pragma: no cover


### PR DESCRIPTION
fixes #44 

This still doesn't fix the case of using the `native=True` option (returning a native `pymmcore` objects) ... but those should be less likely.
Tried to find a way to make sure we can serialize everything needed... but it was difficult