### PR TITLE
Set minimum pymmcore version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     numpy
     psutil
     psygnal
-    pymmcore
+    pymmcore>=10.1.1.70.4
     typing-extensions
     useq-schema
 python_requires = >=3.8


### PR DESCRIPTION
This is the version built with proper threading support which is important on many scopes and will crash the callback system.
See https://github.com/micro-manager/pymmcore/issues/49 for more information.