### PR TITLE
Fix Aliased signals

### DIFF
--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -354,5 +354,4 @@ def test_aliased_signals(core: CMMCorePlus):
     xy_cb = MagicMock()
     core.events.xYStagePositionChanged.connect(xy_cb)
     core.setXYPosition(1.0, 1.5)
-    # assert xy_cb.assert_called_once_with("XY", 1.0, 1.5)
     xy_cb.assert_has_calls([call("XY", 1.005, 1.5), call("XY", 1.0, 1.5)])

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -348,3 +348,11 @@ def test_guess_channel_group(core: CMMCorePlus):
         core.channelGroup_pattern = re.compile("Channel")
         chan_group = core.getOrGuessChannelGroup()
         assert chan_group == "Channel"
+
+
+def test_aliased_signals(core: CMMCorePlus):
+    xy_cb = MagicMock()
+    core.events.xYStagePositionChanged.connect(xy_cb)
+    core.setXYPosition(1.0, 1.5)
+    # assert xy_cb.assert_called_once_with("XY", 1.0, 1.5)
+    xy_cb.assert_has_calls([call("XY", 1.005, 1.5), call("XY", 1.0, 1.5)])

--- a/pymmcore_plus/core/_signals.py
+++ b/pymmcore_plus/core/_signals.py
@@ -17,10 +17,8 @@ class _CMMCoreSignaler:
     pixelSizeAffineChanged = Signal(float, float, float, float, float, float)
     stagePositionChanged = Signal(str, float)
     XYStagePositionChanged = Signal(str, float, float)
-    xYStagePositionChanged = XYStagePositionChanged  # alias
     exposureChanged = Signal(str, float)
     SLMExposureChanged = Signal(str, float)
-    sLMExposureChanged = SLMExposureChanged  # alias
 
     # added for CMMCorePlus
     sequenceStarted = Signal(MDASequence)  # at the start of an MDA sequence
@@ -28,3 +26,12 @@ class _CMMCoreSignaler:
     sequenceCanceled = Signal(MDASequence)  # when mda is canceled
     sequenceFinished = Signal(MDASequence)  # when mda is done (whether canceled or not)
     frameReady = Signal(np.ndarray, MDAEvent)  # after each event in the sequence
+
+    # aliases for lower casing
+    @property
+    def xYStagePositionChanged(self):
+        return self.XYStagePositionChanged
+
+    @property
+    def sLMExposureChanged(self):
+        return self.SLMExposureChanged


### PR DESCRIPTION
Something about the way the signals we're being aliased on the `CMMCoreSignaler` object was not working so the `XYStagePosition` callback was not functioning. It's a bit confusing because I think this used to work but now isn't ??

First commit fails pytest locally, just pushing that to see if it fails CI as well.

Next commit does the aliasing using properties (https://stackoverflow.com/a/11050226/835607) which seems to fix things. I will push that after the tests run.

Fixes: https://github.com/tlambert03/pymmcore-plus/issues/63