### PR TITLE
getOrGuessChannelGroup -> list

### DIFF
--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -331,9 +331,6 @@ def test_get_objectives(core: CMMCorePlus):
 
 def test_guess_channel_group(core: CMMCorePlus):
 
-    chan_group = core.getChannelGroup()
-    assert chan_group == ""
-
     assert core.getOrGuessChannelGroup() == ["Channel"]
 
     with patch.object(core, "getChannelGroup", return_value=""):

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -340,7 +340,7 @@ def test_guess_channel_group(core: CMMCorePlus):
             core.channelGroup_pattern = 4
 
         # assign a new regex that won't match Channel using a str
-        # this will return all the mm groups, but that's because this a bad regex
+        # this will return all the mm groups except Channel, but that's because this a bad regex
         # to use
         core.channelGroup_pattern = "^((?!(Channel)).)*$"
         assert core.getOrGuessChannelGroup() == [

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -347,7 +347,10 @@ def test_guess_channel_group(core: CMMCorePlus):
         # to use
         core.channelGroup_pattern = "^((?!(Channel)).)*$"
         assert core.getOrGuessChannelGroup() == [
-            "Camera", "LightPath", "Objective", "System" 
+            "Camera",
+            "LightPath",
+            "Objective",
+            "System",
         ]
 
         # assign new using a pre-compile pattern

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -347,7 +347,10 @@ def test_guess_channel_group(core: CMMCorePlus):
         # to use
         core.channelGroup_pattern = "^((?!(Channel)).)*$"
         assert core.getOrGuessChannelGroup() == [
-            "Camera", "LightPath", "Objective", "System" 
+            "Camera",
+            "LightPath",
+            "Objective",
+            "System",
         ]
 
         # assign new using a pre-compile pattern
@@ -361,4 +364,3 @@ def test_aliased_signals(core: CMMCorePlus):
     core.events.xYStagePositionChanged.connect(xy_cb)
     core.setXYPosition(1.0, 1.5)
     xy_cb.assert_has_calls([call("XY", 1.005, 1.5), call("XY", 1.0, 1.5)])
-

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -330,21 +330,27 @@ def test_get_objectives(core: CMMCorePlus):
 
 
 def test_guess_channel_group(core: CMMCorePlus):
+
     chan_group = core.getChannelGroup()
-    assert core.getOrGuessChannelGroup() == chan_group
+    assert chan_group == ""
+
+    assert core.getOrGuessChannelGroup() == ["Channel"]
+
     with patch.object(core, "getChannelGroup", return_value=""):
-        assert core.getOrGuessChannelGroup() == "Channel"
+        assert core.getOrGuessChannelGroup() == ["Channel"]
 
         with pytest.raises(TypeError):
             core.channelGroup_pattern = 4
 
         # assign a new regex that won't match Channel using a str
-        # this will return Camera, but that's because this a bad regex
+        # this will return all the mm groups, but that's because this a bad regex
         # to use
         core.channelGroup_pattern = "^((?!(Channel)).)*$"
-        assert core.getOrGuessChannelGroup() == "Camera"
+        assert core.getOrGuessChannelGroup() == [
+            "Camera", "LightPath", "Objective", "System" 
+        ]
 
         # assign new using a pre-compile pattern
         core.channelGroup_pattern = re.compile("Channel")
         chan_group = core.getOrGuessChannelGroup()
-        assert chan_group == "Channel"
+        assert chan_group == ["Channel"]

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -331,6 +331,9 @@ def test_get_objectives(core: CMMCorePlus):
 
 def test_guess_channel_group(core: CMMCorePlus):
 
+    chan_group = core.getChannelGroup()
+    assert chan_group == "Channel"
+
     assert core.getOrGuessChannelGroup() == ["Channel"]
 
     with patch.object(core, "getChannelGroup", return_value=""):
@@ -340,24 +343,14 @@ def test_guess_channel_group(core: CMMCorePlus):
             core.channelGroup_pattern = 4
 
         # assign a new regex that won't match Channel using a str
-        # this will return all the mm groups except Channel, but that's because this a bad regex
+        # this will return all the mm groups, but that's because this a bad regex
         # to use
         core.channelGroup_pattern = "^((?!(Channel)).)*$"
         assert core.getOrGuessChannelGroup() == [
-            "Camera",
-            "LightPath",
-            "Objective",
-            "System",
+            "Camera", "LightPath", "Objective", "System" 
         ]
 
         # assign new using a pre-compile pattern
         core.channelGroup_pattern = re.compile("Channel")
         chan_group = core.getOrGuessChannelGroup()
         assert chan_group == ["Channel"]
-
-
-def test_aliased_signals(core: CMMCorePlus):
-    xy_cb = MagicMock()
-    core.events.xYStagePositionChanged.connect(xy_cb)
-    core.setXYPosition(1.0, 1.5)
-    xy_cb.assert_has_calls([call("XY", 1.005, 1.5), call("XY", 1.0, 1.5)])

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -369,7 +369,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             for group in self.getAvailableConfigGroups():
                 if self._channel_group_regex.match(group):
                     channel_guess.append(group)
-                return group
+                return channel_guess
         elif chan_group in self.getAvailableConfigGroups():
             return [chan_group]
 

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -348,7 +348,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     def getOrGuessChannelGroup(self) -> List[str]:
         """
-        Get the channelGroup or find a likely candidate.
+        Get the channelGroup or find a likely set of candidates.
 
         If the group is not defined via ``.getChannelGroup`` then likely candidates
         will be found by searching for config groups with names that match this
@@ -356,10 +356,6 @@ class CMMCorePlus(pymmcore.CMMCore):
         with a default value of::
 
             reg = re.compile("(chan{1,2}(el)?|filt(er)?)s?", re.IGNORECASE)
-
-
-        If the config group name does not match one of the available config groups
-        then *None* will be returned.
 
         """
         chan_group = self.getChannelGroup()

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -200,6 +200,11 @@ class CMMCorePlus(pymmcore.CMMCore):
         cfg = super().getSystemStateCache()
         return cfg if native else Configuration.from_configuration(cfg)
 
+    def getPixelSizeConfigData(self, *, native=False) -> Configuration:
+        """Returns the entire system state from cache"""
+        cfg = super().getSystemStateCache()
+        return cfg if native else Configuration.from_configuration(cfg)
+
     # metadata overloads that don't require instantiating metadata first
 
     def getLastImageMD(

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -346,7 +346,7 @@ class CMMCorePlus(pymmcore.CMMCore):
                 devices.append(device)
         return devices
 
-    def getOrGuessChannelGroup(self) -> str | None:
+    def getOrGuessChannelGroup(self) -> List[str]:
         """
         Get the channelGroup or find a likely candidate.
 
@@ -365,11 +365,38 @@ class CMMCorePlus(pymmcore.CMMCore):
         chan_group = self.getChannelGroup()
         if chan_group == "":
             # not set in core. Try "Channel" and other variations as fallbacks
+            channel_guess = []
             for group in self.getAvailableConfigGroups():
                 if self._channel_group_regex.match(group):
-                    return group
+                    channel_guess.append(group)
+                return group
         elif chan_group in self.getAvailableConfigGroups():
-            return chan_group
+            return [chan_group]
+
+    # def getOrGuessChannelGroup(self) -> str | None:
+    #     """
+    #     Get the channelGroup or find a likely candidate.
+
+    #     If the group is not defined via ``.getChannelGroup`` then likely candidates
+    #     will be found by searching for config groups with names that match this
+    #     object's ``channelGroup_pattern`` property. This is a settable property
+    #     with a default value of::
+
+    #         reg = re.compile("(chan{1,2}(el)?|filt(er)?)s?", re.IGNORECASE)
+
+
+    #     If the config group name does not match one of the available config groups
+    #     then *None* will be returned.
+
+    #     """
+    #     chan_group = self.getChannelGroup()
+    #     if chan_group == "":
+    #         # not set in core. Try "Channel" and other variations as fallbacks
+    #         for group in self.getAvailableConfigGroups():
+    #             if self._channel_group_regex.match(group):
+    #                 return group
+    #     elif chan_group in self.getAvailableConfigGroups():
+    #         return chan_group
 
     def setRelativeXYZPosition(
         self, dx: float = 0, dy: float = 0, dz: float = 0

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -363,15 +363,14 @@ class CMMCorePlus(pymmcore.CMMCore):
 
         """
         chan_group = self.getChannelGroup()
-        if chan_group == "":
-            # not set in core. Try "Channel" and other variations as fallbacks
-            channel_guess = []
-            for group in self.getAvailableConfigGroups():
-                if self._channel_group_regex.match(group):
-                    channel_guess.append(group)
-                return channel_guess
-        elif chan_group in self.getAvailableConfigGroups():
+        if chan_group:
             return [chan_group]
+        # not set in core. Try "Channel" and other variations as fallbacks
+        channel_guess = []
+        for group in self.getAvailableConfigGroups():
+            if self._channel_group_regex.match(group):
+                channel_guess.append(group)
+        return channel_guess
 
     # def getOrGuessChannelGroup(self) -> str | None:
     #     """

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -368,31 +368,6 @@ class CMMCorePlus(pymmcore.CMMCore):
                 channel_guess.append(group)
         return channel_guess
 
-    # def getOrGuessChannelGroup(self) -> str | None:
-    #     """
-    #     Get the channelGroup or find a likely candidate.
-
-    #     If the group is not defined via ``.getChannelGroup`` then likely candidates
-    #     will be found by searching for config groups with names that match this
-    #     object's ``channelGroup_pattern`` property. This is a settable property
-    #     with a default value of::
-
-    #         reg = re.compile("(chan{1,2}(el)?|filt(er)?)s?", re.IGNORECASE)
-
-
-    #     If the config group name does not match one of the available config groups
-    #     then *None* will be returned.
-
-    #     """
-    #     chan_group = self.getChannelGroup()
-    #     if chan_group == "":
-    #         # not set in core. Try "Channel" and other variations as fallbacks
-    #         for group in self.getAvailableConfigGroups():
-    #             if self._channel_group_regex.match(group):
-    #                 return group
-    #     elif chan_group in self.getAvailableConfigGroups():
-    #         return chan_group
-
     def setRelativeXYZPosition(
         self, dx: float = 0, dy: float = 0, dz: float = 0
     ) -> None:


### PR DESCRIPTION
As for the `guessObjectiveDevices()` method, maybe it is good to have the `getOrGuessChannelGroup()` method returning a list of possible match instead of just the first one that is found (it is possible to have more than one channel group match using the regex `re.compile("(chan{1,2}(el)?|filt(er)?)s?", re.IGNORECASE)`)

The updated method can be like this:
```
chan_group = self.getChannelGroup()
if chan_group:
    return [chan_group]
# not set in core. Try "Channel" and other variations as fallbacks
channel_guess = []
for group in self.getAvailableConfigGroups():
    if self._channel_group_regex.match(group):
        channel_guess.append(group)
return channel_guess
```