### PR TITLE
Download latest MM by default

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,11 +36,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[testing]
 
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m")"
+        shell: bash
+
       - uses: actions/cache@v2
         id: cache
         with:
           path: pymmcore_plus/Micro-Manager-*
-          key: ${{ hashFiles('pymmcore_plus/install.py') }}
+          # update cache monthly, or when install.py file changes
+          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('pymmcore_plus/install.py') }}
 
       - name: Install Micro-Manager
         if: steps.cache.outputs.cache-hit != 'true'

--- a/pymmcore_plus/install.py
+++ b/pymmcore_plus/install.py
@@ -1,18 +1,15 @@
 import os
+import re
 import shutil
 import ssl
 import urllib.request
 from pathlib import Path
 from subprocess import run
 
+_version_regex = re.compile(r"(\d+\.){2}\d+")
 VERSION = "2.0.1"
 RELEASE = 20211007
 DEFAULT_DEST = Path(__file__).parent
-fname = (
-    f"MMSetup_64bit_{VERSION}_{RELEASE}.exe"
-    if os.name == "nt"
-    else f"Micro-Manager-{VERSION}-{RELEASE}.dmg"
-)
 
 ssl._create_default_https_context = ssl._create_unverified_context
 
@@ -33,9 +30,15 @@ def download_url(url, output_path):
     urllib.request.urlretrieve(url, filename=output_path, reporthook=progressBar)
 
 
-def _mac_main(dest_dir=DEFAULT_DEST, release=RELEASE):
-    url = "https://valelab4.ucsf.edu/~MM/nightlyBuilds/2.0/Mac/"
-    dst = dest_dir / f"{fname[:-4]}_mac"
+def _mac_main(dest_dir=DEFAULT_DEST, version=VERSION, release=RELEASE):
+    if release == "latest":
+        url = "https://download.micro-manager.org/latest-experimental/macos/"
+        fname = "Micro-Manager-x86_64-latest.dmg"
+        dst = dest_dir / "Micro-Manager-latest_mac"
+    else:
+        url = "https://valelab4.ucsf.edu/~MM/builds/2.0/Mac/"
+        fname = f"Micro-Manager-{version}-{release}.dmg"
+        dst = dest_dir / f"{fname[:-4]}_mac"
 
     if dst.exists():
         resp = input(f"Micro-manager already exists at\n{dst}\nOverwrite [Y/n]?")
@@ -45,7 +48,10 @@ def _mac_main(dest_dir=DEFAULT_DEST, release=RELEASE):
 
     download_url(f"{url}{fname}", fname)
     run(["hdiutil", "attach", "-nobrowse", fname], check=True)
-    src = f"/Volumes/Micro-Manager/{fname[:-4]}"
+    try:
+        src = next(Path("/Volumes/Micro-Manager").glob("Micro-Manager*"))
+    except StopIteration:
+        src = f"/Volumes/Micro-Manager/{fname[:-4]}"
     shutil.copytree(src, dst, dirs_exist_ok=True)
     run(["hdiutil", "detach", "/Volumes/Micro-Manager"], check=True)
     os.unlink(fname)
@@ -63,9 +69,15 @@ def _mac_main(dest_dir=DEFAULT_DEST, release=RELEASE):
     return dst
 
 
-def _win_main(dest_dir=DEFAULT_DEST, release=RELEASE):
-    url = "https://valelab4.ucsf.edu/~MM/nightlyBuilds/2.0/Windows/"
-    dst = dest_dir / f"Micro-Manager-{VERSION}-{RELEASE}_win"
+def _win_main(dest_dir=DEFAULT_DEST, version=VERSION, release=RELEASE):
+    if release == "latest":
+        url = "https://download.micro-manager.org/latest-experimental/windows/"
+        fname = "MMSetup_x64_latest.exe"
+        dst = dest_dir / "Micro-Manager-latest_win"
+    else:
+        url = f"https://valelab4.ucsf.edu/~MM/nightlyBuilds/{version}/Windows/"
+        dst = dest_dir / f"Micro-Manager-{version}-{release}_win"
+        fname = f"MMSetup_64bit_{version}_{release}.exe"
 
     if dst.exists():
         resp = input(f"Micro-manager already exists at\n{dst}\nOverwrite [Y/n]?")
@@ -82,8 +94,12 @@ def _win_main(dest_dir=DEFAULT_DEST, release=RELEASE):
     return dst
 
 
-def install(dest_dir=DEFAULT_DEST):
-    out = _win_main(dest_dir) if os.name == "nt" else _mac_main(dest_dir)
+def install(dest_dir=DEFAULT_DEST, version=VERSION, release="latest"):
+    out = (
+        _win_main(dest_dir, version, release)
+        if os.name == "nt"
+        else _mac_main(dest_dir, version, release)
+    )
     if out:
         print("installed to", out)
 
@@ -95,7 +111,17 @@ def _existing_dir(string):
     return path
 
 
-def _dateint(value):
+def _version(value: str):
+    if not _version_regex.match(value):
+        raise ValueError(
+            f"Invalid version: {value}. Must be of form x.y.z with x y and z in 0-9"
+        )
+    return value
+
+
+def _release(value: str):
+    if value.lower() == "latest":
+        return "latest"
     if len(value) != 8:
         raise ValueError(f"Invalid date: {value}. Must be eight digits.")
     return int(value)
@@ -115,18 +141,28 @@ def main():
         type=_existing_dir,
         help=f"Directory in which to install (default: {DEFAULT_DEST})",
     )
+
+    parser.add_argument(
+        "-v",
+        "--version",
+        metavar="VERSION",
+        type=_version,
+        default=VERSION,
+        help="Version number. e.g. 2.0.1 - ignored if release=latest "
+        f"(default: {VERSION})",
+    )
     parser.add_argument(
         "-r",
         "--release",
         metavar="DATE",
-        type=_dateint,
-        default=RELEASE,
-        help="8 digit date (YYYYMMDD) of MM nightly build to fetch "
-        f"(default: {RELEASE})",
+        type=_release,
+        default="latest",
+        help='8 digit date (YYYYMMDD) of MM nightly build to fetch, or "latest" '
+        "(default: latest)",
     )
 
     args = parser.parse_args()
-    install(args.dest)
+    install(args.dest, args.version, args.release)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is possible now with the new download URLs from https://github.com/micro-manager/download-mm/issues/2

Also update the github action caching to update monthly as new caches will not longer be triggered as often by updating the version and release strings in the install.py file. 

It is also now possible to manually specify both the version and the release. Also, previously the `--release` arg had no effect which should be fixed.
