### PR TITLE
Add a `snap` method and `signal`

### DIFF
--- a/pymmcore_plus/client/callbacks/qcallback.py
+++ b/pymmcore_plus/client/callbacks/qcallback.py
@@ -26,6 +26,7 @@ class QCoreCallback(QObject):
     sequenceCanceled = Signal(object)  # when mda is canceled
     sequenceFinished = Signal(object)  # when mda is done (whether canceled or not)
     frameReady = Signal(object, object)  # after each event in the sequence
+    imageSnapped = Signal(object)  # after an image is snapped
 
     @expose
     def receive_core_callback(self, signal_name, args):

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -491,6 +491,30 @@ class CMMCorePlus(pymmcore.CMMCore):
             img = img.reshape(new_shape)[:, :, (2, 1, 0, 3)]  # mmcore gives bgra
         return img
 
+    def snap(self, *args, fix=True) -> np.ndarray:
+        """
+        snap and return an image.
+
+        In contrast to ``snapImage`` this will directly return the image
+        without also calling ``getImage``.
+
+        Parameters
+        ----------
+        *args :
+            Passed through to ``getImage``
+        fix : bool, default: True
+            Whether to fix the shape of images with n_components >1
+            Pass on to ``getImage``
+
+        Returns
+        -------
+        img : np.ndarray
+        """
+        self.snapImage()
+        img = self.getImage()
+        self.events.imageSnapped.emit(img)
+        return img
+
     def getImage(self, *args, fix=True) -> np.ndarray:
         """Exposes the internal image buffer.
 

--- a/pymmcore_plus/core/_signals.py
+++ b/pymmcore_plus/core/_signals.py
@@ -26,6 +26,7 @@ class _CMMCoreSignaler:
     sequenceCanceled = Signal(MDASequence)  # when mda is canceled
     sequenceFinished = Signal(MDASequence)  # when mda is done (whether canceled or not)
     frameReady = Signal(np.ndarray, MDAEvent)  # after each event in the sequence
+    imageSnapped = Signal(np.ndarray)  # whenever snap is called
 
     # aliases for lower casing
     @property


### PR DESCRIPTION
1. Add a `snap` method
This is a nice convenience that I've always wanted

2. Add an `imageSnapped` signal

This is will be nice for example when you have opened napari from ipython and are combining scripting and the GUI. e.g. I have some callback that modifies an overlay layer (i.e. cell detection) that I want to run whenever I snap an image either from the gui or from code.