### PR TITLE
Fix flaky metadata test

### DIFF
--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -241,8 +241,8 @@ def test_metadata(core: CMMCorePlus):
     image, md = core.getLastImageMD()
     assert isinstance(md, Metadata)
     assert md["Height"] == "512"
-    assert "Binning" in md.keys()
-    assert ("ImageNumber", "0") in md.items()
+    assert "ImageNumber" in md.keys()
+    assert ("Binning", "1") in md.items()
     assert "GRAY16" in md.values()
 
     assert "Camera" in md


### PR DESCRIPTION
This test fails a lot because `ImageNumber` is sometimes 1... should have picked another item to test