### PR TITLE
Ensure propertyChanged event occurs for setState and setStateLabel

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 85%
+comment:
+  require_changes: true

--- a/examples/properties_and_state_events.py
+++ b/examples/properties_and_state_events.py
@@ -1,0 +1,17 @@
+from pymmcore_plus import CMMCorePlus
+
+core = CMMCorePlus.instance()
+core.loadSystemConfiguration()
+
+
+# Note that when state devices change either the state or the label
+# TWO propertyChanged events will be emitted, one for prop 'State'
+# and one for prop 'Label'.
+# Probably, best to check the property name and only respond to one of them
+@core.events.propertyChanged.connect
+def _on_prop_changed(dev, prop, value):
+    if dev == "Objective" and prop == "Label":
+        print("new objective is", value)
+
+
+core.setState("Objective", 3)

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -353,6 +353,28 @@ def test_set_property_events(core: CMMCorePlus):
     mock.assert_called_once_with("Camera", "AllowMultiROI", "1")
 
 
+def test_set_state_events(core: CMMCorePlus):
+    mock = MagicMock()
+    core.events.propertyChanged.connect(mock)
+    assert core.getState("Objective") == 1
+    core.setState("Objective", 3)
+    mock.assert_has_calls(
+        [
+            call("Objective", "State", "3"),
+            call("Objective", "Label", "Nikon 20X Plan Fluor ELWD"),
+        ]
+    )
+    assert core.getState("Objective") == 3
+
+    mock.reset_mock()
+    assert core.getState("Dichroic") == 0
+    core.setState("Dichroic", 1)
+    mock.assert_has_calls(
+        [call("Dichroic", "State", "1"), call("Dichroic", "Label", "Q505LP")]
+    )
+    assert core.getState("Dichroic") == 1
+
+
 def test_get_objectives(core: CMMCorePlus):
     devices = core.guessObjectiveDevices()
     assert len(devices) == 1

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -368,7 +368,7 @@ def test_set_state_events(core: CMMCorePlus):
 
     mock.reset_mock()
     assert core.getState("Dichroic") == 0
-    core.setState("Dichroic", 1)
+    core.setStateLabel("Dichroic", "Q505LP")
     mock.assert_has_calls(
         [call("Dichroic", "State", "1"), call("Dichroic", "Label", "Q505LP")]
     )

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -17,6 +17,7 @@ from typing import (
     List,
     Optional,
     Pattern,
+    Sequence,
     Tuple,
     TypeVar,
     Union,
@@ -111,38 +112,25 @@ class CMMCorePlus(pymmcore.CMMCore):
     def setProperty(
         self, label: str, propName: str, propValue: Union[bool, float, int, str]
     ) -> None:
-        """setProperty with more reliable event emission.
-
-        As stated by Nico: "Callbacks are mainly used to give devices the opportunity to
-        signal back to the UI."
-        https://forum.image.sc/t/micromanager-events-core-events-not-coming-through/53014/2
-
-        Because it's left to the device adapter to emit a signal, in many cases uses
-        `setProperty()` will NOT lead to a new `propertyChanged` event getting emitted.
-        But that makes it hard to create listeners (i.e. in the gui or elsewhere).
-
-        While this method override cannot completely solve that problem (core-internal
-        changes will still lack an associated event emission in many cases), it can at
-        least guarantee that if we use `CMMCorePlus.setProperty` to change the property,
-        then a `propertyChanged` event will be emitted if the value did indeed change.
-
-        Parameters
-        ----------
-        label : str
-            device label
-        propName : str
-            property name
-        propValue : Union[bool, float, int, str]
-            new value
-        """
-        before = super().getProperty(label, propName)
-        with _blockSignal(
-            self.events, self.events.propertyChanged
-        ):  # block the native event.
+        """setProperty with reliable event emission."""
+        with self._property_change_emission_ensured(label, (propName,)):
             super().setProperty(label, propName, propValue)
-        after = super().getProperty(label, propName)
-        if before != after:
-            self.events.propertyChanged.emit(label, propName, after)
+
+    @synchronized(lock)
+    def setState(self, stateDeviceLabel: str, state: int) -> None:
+        """Set state (by position) on stateDeviceLabel, with reliable event emission."""
+        with self._property_change_emission_ensured(
+            stateDeviceLabel, ("State", "Label")
+        ):
+            super().setState(stateDeviceLabel, state)
+
+    @synchronized(lock)
+    def setStateLabel(self, stateDeviceLabel: str, stateLabel: str) -> None:
+        """Set state (by label) on stateDeviceLabel, with reliable event emission."""
+        with self._property_change_emission_ensured(
+            stateDeviceLabel, ("State", "Label")
+        ):
+            super().setStateLabel(stateDeviceLabel, stateLabel)
 
     def setDeviceAdapterSearchPaths(self, adapter_paths: ListOrTuple[str]) -> None:
         # add to PATH as well for dynamic dlls
@@ -620,6 +608,39 @@ class CMMCorePlus(pymmcore.CMMCore):
             "XYStageDevice": self.getXYStageDevice(),  # 156 ns
             "ZPosition": self.getZPosition(),  # 1.03 µs
         }
+
+    @contextmanager
+    def _property_change_emission_ensured(self, device: str, properties: Sequence[str]):
+        """Context that emits events if any of `properties` change on device.
+
+        As stated by Nico: "Callbacks are mainly used to give devices the opportunity to
+        signal back to the UI."
+        https://forum.image.sc/t/micromanager-events-core-events-not-coming-through/53014/2
+
+        Because it's left to the device adapter to emit a signal, in many cases uses
+        `setProperty()` will NOT lead to a new `propertyChanged` event getting emitted.
+        But that makes it hard to create listeners (i.e. in the gui or elsewhere).
+
+        While this method override cannot completely solve that problem (core-internal
+        changes will still lack an associated event emission in many cases), it can at
+        least guarantee that if we use `CMMCorePlus.setProperty` to change the property,
+        then a `propertyChanged` event will be emitted if the value did indeed change.
+
+        Parameters
+        ----------
+        device : str
+            a device label
+        properties : Sequence[str]
+            a sequence of property names to monitor
+        """
+
+        before = [self.getProperty(device, p) for p in properties]
+        with _blockSignal(self.events, self.events.propertyChanged):
+            yield
+        after = [self.getProperty(device, p) for p in properties]
+        if before != after:
+            for val in enumerate(after):
+                self.events.propertyChanged.emit(device, properties[0], val)
 
 
 for name in (

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -626,6 +626,8 @@ class CMMCorePlus(pymmcore.CMMCore):
         least guarantee that if we use `CMMCorePlus.setProperty` to change the property,
         then a `propertyChanged` event will be emitted if the value did indeed change.
 
+        NOTE: Depending on device adapter behavior the signal may be emitted twice.
+
         Parameters
         ----------
         device : str

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -639,8 +639,8 @@ class CMMCorePlus(pymmcore.CMMCore):
             yield
         after = [self.getProperty(device, p) for p in properties]
         if before != after:
-            for val in enumerate(after):
-                self.events.propertyChanged.emit(device, properties[0], val)
+            for i, val in enumerate(after):
+                self.events.propertyChanged.emit(device, properties[i], val)
 
 
 for name in (


### PR DESCRIPTION
Akin to #38, when `core.setState()` is called it will _sometimes_ cause a `core.events.propertyChanged` event to be emitted, in a device-dependent manor.  (for example, in the demo config, it works for `Objective`, but not for `Dichroic`).  This pulls the logic from #38 into a more generally useful context manager and uses it for `setState` and `setStateLabel` as well