### PR TITLE
undo subclass of QCoreSignaler in remote

### DIFF
--- a/pymmcore_plus/remote/client/callbacks/qcallback.py
+++ b/pymmcore_plus/remote/client/callbacks/qcallback.py
@@ -1,12 +1,36 @@
 from Pyro5.api import expose
-from qtpy.QtCore import Signal
+from qtpy.QtCore import QObject, Signal
 
-from ....core.events import _qsignals
+# For some reason, subclassing from core.events._qsignals seems to sometimes affect
+# the event emission order in the tests.  Not sure why, so keeping this as it's own
+# class for now
 
 
-class QCoreSignaler(_qsignals.QCoreSignaler):
-    # not sure why, but this seems to need to be here for the order of emission test.
-    frameReady = Signal(object, object)
+class QCoreSignaler(QObject):
+
+    # native MMCore callback events
+    propertiesChanged = Signal()
+    propertyChanged = Signal(str, str, object)
+    channelGroupChanged = Signal(str)
+    configGroupChanged = Signal(str, str)
+    configSet = Signal(str, str)
+    systemConfigurationLoaded = Signal()
+    pixelSizeChanged = Signal(float)
+    pixelSizeAffineChanged = Signal(float, float, float, float, float, float)
+    stagePositionChanged = Signal(str, float)
+    XYStagePositionChanged = Signal(str, float, float)
+    xYStagePositionChanged = XYStagePositionChanged  # alias
+    exposureChanged = Signal(str, float)
+    SLMExposureChanged = Signal(str, float)
+    sLMExposureChanged = SLMExposureChanged  # alias
+
+    # added for CMMCorePlus
+    sequenceStarted = Signal(object)  # at the start of an MDA sequence
+    sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
+    sequenceCanceled = Signal(object)  # when mda is canceled
+    sequenceFinished = Signal(object)  # when mda is done (whether canceled or not)
+    frameReady = Signal(object, object)  # after each event in the sequence
+    imageSnapped = Signal(object)  # after an image is snapped
 
     @expose
     def receive_core_callback(self, signal_name, args):


### PR DESCRIPTION
in #98, I tried to reduce code duplication by subclassing QCoreSignaller in the remote module from the one in core.events.  I think this was _very_ rarely causing a change in event emission order in the tests. so I'm reverting that change until I learn more