### PR TITLE
Switch to user swappable mda-engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@
 
   ```py
   from pymmcore_plus import CMMCorePlus
+  core = CMMCorePlus.instance()
+  core.loadSystemConfiguration() # loads demo config
+  print(core.getLoadedDevices())
   ```
 - `CMMCorePlus` includes a `run_mda` method (name may change) "acquisition engine" that drives micro-manager for conventional multi-dimensional experiments. It accepts an [MDASequence](https://github.com/tlambert03/useq-schema#mdasequence) from [useq-schema](https://github.com/tlambert03/useq-schema) for experiment design/declaration.
 - Adds a callback system that adapts the CMMCore callback object to an existing python event loop (such as Qt, or perhaps asyncio/etc...)
-- Includes an experimental [Pyro5](https://pyro5.readthedocs.io/en/latest/)-based client/server that allows one to create and control and CMMCorePlus instance running in another process, or (conceivably) another computer.  To use this feature, install with `pip install pymmcore-plus[remote]`.  (Do try using the single-process `CMMCorePlus` first, as the interprocess variant is still buggy).
+- Includes an experimental [Pyro5](https://pyro5.readthedocs.io/en/latest/)-based client/server that allows one to create and control and CMMCorePlus instance running in another process, or (conceivably) another computer.  To use this feature, install with `pip install pymmcore-plus[remote]`.  (Do try using the single-process `CMMCorePlus` first, as the interprocess variant is still buggy and does not support MDAs).
 
   ```py
   from pymmcore_plus import RemoteMMCore
 
   with RemoteMMCore() as mmcore:
-      mmcore.loadSystemConfiguration("demo")
+      mmcore.loadSystemConfiguration()
       print(mmcore.getLoadedDevices())
   ```
 
@@ -66,7 +69,7 @@ instead of a Java process).
 Finally, the `CMMCorePlus` class here adds a callback mechanism that makes it
 easier to adapt the native MMCore callback system to multiple listeners, across
 multiple process, which makes it easier to incorporate `pymmcore-plus` into
-existing event loops (like a [Qt event loop](examples/qt_integration.py)).  See
+existing event loops (like a [Qt event loop](docs/examples/integration-with-qt.md)).  See
 [`napari-micromanager`](https://github.com/tlambert03/napari-micromanager) for a
 nascent project that adds Qt-based GUI interface for micro-manager.
 
@@ -139,7 +142,7 @@ sequence = MDASequence(
 
 mmc = CMMCorePlus()
 # this will load the `MMConfig_demo.cfg` in your micromanager path
-mmc.loadSystemConfiguration("demo")
+mmc.loadSystemConfiguration()
 mmc.run_mda(sequence)
 ```
 
@@ -154,22 +157,15 @@ python examples/basic_client.py
 from pymmcore_plus import RemoteMMCore
 
 with RemoteMMCore() as mmcore:
-    mmcore.loadSystemConfiguration("demo")
+    mmcore.loadSystemConfiguration()
     print("loaded:", mmcore.getLoadedDevices())
     ...
 ```
 
 #### use with an event loop
 
-see [`qt_integration`](examples/qt_integration.py) for a slightly more 'realistic'
-example that drives an experiment in another process using a `RemoteMMCore` proxy,
-while receiving feedback in a Qt event loop in the main python thread.
-
-```sh
-python examples/qt_integration.py
-```
-
-> note: you'll need to `pip install qtpy pyqt5` (or `pyside2`) for this to work
+see [`qt_integration`](docs/examples/integration-with-qt.md) for a slightly more 'realistic'
+example that drives an experiment using threads.
 
 
 ## Contributing

--- a/docs/examples/mda.md
+++ b/docs/examples/mda.md
@@ -75,3 +75,11 @@ acquisition engine and register it use {func}`~pymmcore_plus.core.register_mda_e
 
 Your engine must conform to the engine protocol defined by {class}`~pymmcore_plus.mda.PMDAEngine`. To ensure that your engine
 conforms you can inherit from the protocol.
+
+
+You can be alerted to the the registering of a new engine with the {class}`~pymmcore_plus.core.events.CMMCoreSignaler.mdaEngineRegistered` signal.
+```python
+def new_engine(new_engine, old_engine):
+    print('new engine registered!")
+mmc.events.mdaEngineRegistered(new_engine)
+```

--- a/docs/examples/mda.md
+++ b/docs/examples/mda.md
@@ -26,7 +26,7 @@ sequence = MDASequence(
 )
 ```
 
-There are 5 signals on the `events` object that can be used to run callbacks when mda events happen. They are:
+There are 5 signals on the `mda.events` object that can be used to run callbacks when mda events happen. They are:
 
 ```python
 sequenceStarted = Signal(MDASequence)  # at the start of an MDA sequence
@@ -40,7 +40,7 @@ to use then connect a callback function like so:
 
 ```python
 # connect as a decorator
-@mmc.events.sequenceStarted.connect
+@mmc.mda.events.sequenceStarted.connect
 def seq_started(seq: MDASequence):
     print(seq)
 
@@ -48,7 +48,7 @@ def seq_started(seq: MDASequence):
 def frameReady(img: np.ndarray, event: MDAEvent)
     print(img)
 
-mmc.events.frameReady.connect(frameReady)
+mmc.mda.events.frameReady.connect(frameReady)
 ```
 
 
@@ -63,5 +63,15 @@ thead = mmc.run_mda(sequence)
 
 ## Cancelling or Pausing
 
-You can always pause or cancel the mda with the {func}`~pymmcore_plus.CMMCorePlus.toggle_pause`
-or {func}`~pymmcore_plus.CMMCorePlus.cancel` methods.
+You can always pause or cancel the mda with the {func}`~pymmcore_plus.mda.MDAEngine.toggle_pause`
+or {func}`~pymmcore_plus.mda.MDAEngine.cancel` methods.
+
+
+## Registering a new MDA Engine
+
+By default {class}`~pymmcore_plus.mda.MDAEngine` will be the engine used to run the MDA. However, you can create a custom
+acquisition engine and register it use {func}`~pymmcore_plus.core.register_mda_engine`.
+
+
+Your engine must conform to the engine protocol defined by {class}`~pymmcore_plus.mda.PMDAEngine`. To ensure that your engine
+conforms you can inherit from the protocol.

--- a/examples/run_mda.py
+++ b/examples/run_mda.py
@@ -10,6 +10,13 @@ sequence = MDASequence(
     axis_order="tpcz",
 )
 
-mmc = CMMCorePlus()
+mmc = CMMCorePlus.instance()
 mmc.loadSystemConfiguration()
+
+
+@mmc.mda.events.frameReady.connect
+def new_frame(img, event):
+    print(img.shape)
+
+
 mda_thread = mmc.run_mda(sequence)

--- a/pymmcore_plus/_tests/conftest.py
+++ b/pymmcore_plus/_tests/conftest.py
@@ -1,22 +1,20 @@
 import pytest
 
 import pymmcore_plus
-
 from pymmcore_plus.core.events import CMMCoreSignaler, QCoreSignaler
 from pymmcore_plus.mda.events import MDASignaler, QMDASignaler
+
 
 @pytest.fixture(params=["QSignal", "psygnal"], scope="function")
 def core(request):
     core = pymmcore_plus.CMMCorePlus()
     if request.param == "psygnal":
-        core.events = pymmcore_plus.CMMCoreSignaler()
+        core.events = CMMCoreSignaler()
         core.mda._events = MDASignaler()
     else:
         core.events = QCoreSignaler()
         core.mda._events = QMDASignaler()
-    core._callback_relay = pymmcore_plus.core._mmcore_plus.MMCallbackRelay(
-        core.events
-    )
+    core._callback_relay = pymmcore_plus.core._mmcore_plus.MMCallbackRelay(core.events)
     core.registerCallback(core._callback_relay)
     if not core.getDeviceAdapterSearchPaths():
         pytest.fail(

--- a/pymmcore_plus/_tests/conftest.py
+++ b/pymmcore_plus/_tests/conftest.py
@@ -2,16 +2,22 @@ import pytest
 
 import pymmcore_plus
 
+from pymmcore_plus.core.events import CMMCoreSignaler, QCoreSignaler
+from pymmcore_plus.mda.events import MDASignaler, QMDASignaler
 
 @pytest.fixture(params=["QSignal", "psygnal"], scope="function")
 def core(request):
     core = pymmcore_plus.CMMCorePlus()
     if request.param == "psygnal":
         core.events = pymmcore_plus.CMMCoreSignaler()
-        core._callback_relay = pymmcore_plus.core._mmcore_plus.MMCallbackRelay(
-            core.events
-        )
-        core.registerCallback(core._callback_relay)
+        core.mda._events = MDASignaler()
+    else:
+        core.events = QCoreSignaler()
+        core.mda._events = QMDASignaler()
+    core._callback_relay = pymmcore_plus.core._mmcore_plus.MMCallbackRelay(
+        core.events
+    )
+    core.registerCallback(core._callback_relay)
     if not core.getDeviceAdapterSearchPaths():
         pytest.fail(
             "To run tests, please install MM with `python -m pymmcore_plus.install`"

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -200,7 +200,7 @@ def test_mda_pause_cancel(core: CMMCorePlus, qtbot):
     sf_mock.assert_called_once_with(mda)
 
 
-def test_register_engine(core: CMMCorePlus, qtbot):
+def test_register_mda_engine(core: CMMCorePlus, qtbot):
     mda = MDASequence(
         time_plan={"interval": 10, "loops": 2},
         stage_positions=[(1, 1, 1)],
@@ -227,6 +227,23 @@ def test_register_engine(core: CMMCorePlus, qtbot):
 
     with pytest.raises(TypeError):
         core.register_mda_engine(nonconforming_engine())
+
+
+def test_not_concurrent_mdas(core):
+    mda = MDASequence(
+        time_plan={"interval": 10, "loops": 2},
+        stage_positions=[(1, 1, 1)],
+        z_plan={"range": 3, "step": 1},
+        channels=[{"config": "DAPI", "exposure": 1}],
+    )
+    core.run_mda(mda)
+    assert core.mda.is_running()
+    with pytest.raises(ValueError):
+        core.run_mda(mda)
+    core.mda.cancel()
+    assert not core.mda.is_running()
+    core.run_mda(mda)
+    core.cancel()
 
 
 def test_device_type_overrides(core: CMMCorePlus):

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -468,3 +468,9 @@ def test_setPosition_overload(core: CMMCorePlus):
     core.setPosition(5)
     dev = core.getFocusDevice()
     core.setPosition(dev, 4)
+
+
+def test_unload_devices(core: CMMCorePlus):
+    assert len(core.getLoadedDevices()) > 2
+    core.unloadAllDevices()
+    assert len(core.getLoadedDevices()) == 1

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -22,7 +22,7 @@ from pymmcore_plus import (
     Metadata,
     PropertyType,
 )
-from pymmcore_plus.core.events import CMMCoreSignaler
+from pymmcore_plus.core.events import CMMCoreSignaler, QCoreSignaler
 from pymmcore_plus.mda import MDAEngine
 
 
@@ -33,6 +33,9 @@ def test_core(core: CMMCorePlus):
     assert core.getDeviceAdapterSearchPaths()
     assert isinstance(
         core.events.propertyChanged, (psygnal.SignalInstance, QSignalInstance)
+    )
+    assert isinstance(
+        core.mda.events.frameReady, (psygnal.SignalInstance, QSignalInstance)
     )
     assert not core.mda._canceled
     assert not core.mda._paused

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -22,7 +22,7 @@ from pymmcore_plus import (
     Metadata,
     PropertyType,
 )
-from pymmcore_plus.core.events import CMMCoreSignaler, QCoreSignaler
+from pymmcore_plus.core.events import CMMCoreSignaler
 from pymmcore_plus.mda import MDAEngine
 
 
@@ -243,7 +243,7 @@ def test_not_concurrent_mdas(core):
     core.mda.cancel()
     assert not core.mda.is_running()
     core.run_mda(mda)
-    core.cancel()
+    core.mda.cancel()
 
 
 def test_device_type_overrides(core: CMMCorePlus):

--- a/pymmcore_plus/_util.py
+++ b/pymmcore_plus/_util.py
@@ -52,7 +52,7 @@ def find_micromanager() -> Optional[str]:
         return None
 
 
-def _check_qt():
+def _qt_app_is_running():
     for modname in {"PyQt5", "PySide2", "PyQt6", "PySide6"}:
         if qmodule := sys.modules.get(modname):
             QtWidgets = getattr(qmodule, "QtWidgets")

--- a/pymmcore_plus/_util.py
+++ b/pymmcore_plus/_util.py
@@ -52,7 +52,7 @@ def find_micromanager() -> Optional[str]:
         return None
 
 
-def _qt_app_is_running():
+def _qt_app_is_running() -> bool:
     for modname in {"PyQt5", "PySide2", "PyQt6", "PySide6"}:
         if qmodule := sys.modules.get(modname):
             QtWidgets = getattr(qmodule, "QtWidgets")

--- a/pymmcore_plus/_util.py
+++ b/pymmcore_plus/_util.py
@@ -50,3 +50,11 @@ def find_micromanager() -> Optional[str]:
     except StopIteration:
         logger.error(f"could not find micromanager directory in {app_path}")
         return None
+
+
+def _check_qt():
+    for modname in {"PyQt5", "PySide2", "PyQt6", "PySide6"}:
+        if qmodule := sys.modules.get(modname):
+            QtWidgets = getattr(qmodule, "QtWidgets")
+            return QtWidgets.QApplication.instance() is not None
+    return False

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -469,6 +469,10 @@ class CMMCorePlus(pymmcore.CMMCore):
         Thread
             The thread the MDA is running on.
         """
+        if self._mda_engine.is_running():
+            raise ValueError(
+                "Cannot start an MDA while the previous MDA is still running."
+            )
         th = Thread(target=self._mda_engine.run, args=(sequence,))
         th.start()
         return th

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -93,7 +93,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         self._callback_relay = MMCallbackRelay(self.events)
         self.registerCallback(self._callback_relay)
 
-        self._mda_engine = MDAEngine(self)
+        self._mda_engine = MDAEngine()
 
         self._objective_regex = _OBJECTIVE_DEVICE_RE
         self._channel_group_regex = _CHANNEL_REGEX

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -476,7 +476,8 @@ class CMMCorePlus(pymmcore.CMMCore):
     def register_mda_engine(self, engine):
         """
         Set the MDA Engine to be used on ``run_mda``. This will unregister
-        the previous engine and emit an ``mdaEngineRegistered`` signal.
+        the previous engine and emit an ``mdaEngineRegistered`` signal. The
+        current Engine must not be running an MDA in order to register a new engine.
 
         Parameters
         ----------
@@ -485,6 +486,12 @@ class CMMCorePlus(pymmcore.CMMCore):
         """
         if not isinstance(engine, PMDAEngine):
             raise TypeError("Engine does not conform to the Engine protocol.")
+        if self._mda_engine.is_running():
+            raise ValueError(
+                "Cannot register a new engine when the current engine is running "
+                "an acquistion. Please cancel the current engine's acquistion "
+                "before registering"
+            )
         previous_engine, self._mda_engine = self._mda_engine, engine
         self.events.mdaEngineRegistered.emit(engine, previous_engine)
 

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -93,7 +93,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         self._callback_relay = MMCallbackRelay(self.events)
         self.registerCallback(self._callback_relay)
 
-        self._mda_engine = MDAEngine()
+        self._mda_engine = MDAEngine(self)
 
         self._objective_regex = _OBJECTIVE_DEVICE_RE
         self._channel_group_regex = _CHANNEL_REGEX

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -458,9 +458,8 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     def register_mda_engine(self, engine):
         if not isinstance(engine, PMDAEngine):
-            raise TypeError("engine must conform to the Engine protocol.")
-        previous_engine = self._mda_engine
-        self._mda_engine = engine
+            raise TypeError("Engine does not conform to the Engine protocol.")
+        previous_engine, self._mda_engine = self._mda_engine, engine
         self.events.mdaEngineRegistered.emit(engine, previous_engine)
 
     def _fix_image(self, img: np.ndarray) -> np.ndarray:

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -452,11 +452,37 @@ class CMMCorePlus(pymmcore.CMMCore):
         return self._mda_engine
 
     def run_mda(self, sequence: MDASequence) -> Thread:
+        """
+        Run MDA defined by *sequence* on a new thread. The currently
+        registered MDAEngine (``core.mda``) will be responsible for executing
+        the acquisition.
+
+        After starting the sequence you can pause or cancel with the mda with
+        the mda object's ``toggle_pause`` and ``cancel`` methods.
+
+        Parameters
+        ----------
+        sequence : useq.MDASequence
+
+        Returns
+        -------
+        Thread
+            The thread the MDA is running on.
+        """
         th = Thread(target=self._mda_engine.run, args=(sequence,))
         th.start()
         return th
 
     def register_mda_engine(self, engine):
+        """
+        Set the MDA Engine to be used on ``run_mda``. This will unregister
+        the previous engine and emit an ``mdaEngineRegistered`` signal.
+
+        Parameters
+        ----------
+        engine : PMDAEngine
+            Any object conforming to the PMDAEngine protocol.
+        """
         if not isinstance(engine, PMDAEngine):
             raise TypeError("Engine does not conform to the Engine protocol.")
         previous_engine, self._mda_engine = self._mda_engine, engine

--- a/pymmcore_plus/core/events/__init__.py
+++ b/pymmcore_plus/core/events/__init__.py
@@ -1,6 +1,6 @@
-import sys
 from typing import TYPE_CHECKING
 
+from ..._util import _check_qt
 from ._protocol import PCoreSignaler
 from ._psygnal import CMMCoreSignaler
 
@@ -11,18 +11,15 @@ __all__ = [
     "CMMCoreSignaler",
     "QCoreSignaler",
     "PCoreSignaler",
-    "_get_auto_callback_class",
+    "_get_auto_core_callback_class",
 ]
 
 
-def _get_auto_callback_class(default=CMMCoreSignaler):
-    for modname in {"PyQt5", "PySide2", "PyQt6", "PySide6"}:
-        if qmodule := sys.modules.get(modname):
-            QtWidgets = getattr(qmodule, "QtWidgets")
-            if QtWidgets.QApplication.instance() is not None:
-                from ._qsignals import QCoreSignaler
+def _get_auto_core_callback_class(default=CMMCoreSignaler):
+    if _check_qt():
+        from ._qsignals import QCoreSignaler
 
-                return QCoreSignaler
+        return QCoreSignaler
 
     return default
 

--- a/pymmcore_plus/core/events/__init__.py
+++ b/pymmcore_plus/core/events/__init__.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from ..._util import _check_qt
+from ..._util import _qt_app_is_running
 from ._protocol import PCoreSignaler
 from ._psygnal import CMMCoreSignaler
 
@@ -16,7 +16,7 @@ __all__ = [
 
 
 def _get_auto_core_callback_class(default=CMMCoreSignaler):
-    if _check_qt():
+    if _qt_app_is_running():
         from ._qsignals import QCoreSignaler
 
         return QCoreSignaler

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -33,9 +33,5 @@ class PCoreSignaler(Protocol):
     sLMExposureChanged: PSignalInstance  # alias
 
     # added for CMMCorePlus
-    sequenceStarted: PSignalInstance
-    sequencePauseToggled: PSignalInstance
-    sequenceCanceled: PSignalInstance
-    sequenceFinished: PSignalInstance
-    frameReady: PSignalInstance
     imageSnapped: PSignalInstance
+    mdaEngineRegistered = PSignalInstance

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -1,6 +1,7 @@
 import numpy as np
 from psygnal import Signal
-from useq import MDAEvent, MDASequence
+
+from ...mda import MDAEngine
 
 
 class CMMCoreSignaler:
@@ -21,12 +22,8 @@ class CMMCoreSignaler:
     SLMExposureChanged = Signal(str, float)
 
     # added for CMMCorePlus
-    sequenceStarted = Signal(MDASequence)  # at the start of an MDA sequence
-    sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
-    sequenceCanceled = Signal(MDASequence)  # when mda is canceled
-    sequenceFinished = Signal(MDASequence)  # when mda is done (whether canceled or not)
-    frameReady = Signal(np.ndarray, MDAEvent)  # after each event in the sequence
     imageSnapped = Signal(np.ndarray)  # whenever snap is called
+    mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -20,9 +20,5 @@ class QCoreSignaler(QObject):
     sLMExposureChanged = SLMExposureChanged  # alias
 
     # added for CMMCorePlus
-    sequenceStarted = Signal(object)  # at the start of an MDA sequence
-    sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
-    sequenceCanceled = Signal(object)  # when mda is canceled
-    sequenceFinished = Signal(object)  # when mda is done (whether canceled or not)
-    frameReady = Signal(object, object)  # after each event in the sequence
     imageSnapped = Signal(object)  # after an image is snapped
+    mdaEngineRegistered = Signal(object, object)  # new engine, old engine

--- a/pymmcore_plus/mda/__init__.py
+++ b/pymmcore_plus/mda/__init__.py
@@ -1,0 +1,3 @@
+from ._engine import MDAEngine, PMDAEngine
+
+__all__ = ["MDAEngine", "PMDAEngine"]

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -1,11 +1,14 @@
 import time
 from abc import abstractmethod
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from loguru import logger
 from useq import MDASequence
 
 from .events import PMDASignaler, _get_auto_MDA_callback_class
+
+if TYPE_CHECKING:
+    from ..core import CMMCorePlus
 
 
 @runtime_checkable
@@ -38,7 +41,8 @@ class PMDAEngine(Protocol):
 
 
 class MDAEngine(PMDAEngine):
-    def __init__(self) -> None:
+    def __init__(self, mmc: "CMMCorePlus" = None) -> None:
+        self._mmc = mmc
         self._events = _get_auto_MDA_callback_class()()
         self._canceled = False
         self._paused = False
@@ -62,7 +66,7 @@ class MDAEngine(PMDAEngine):
         # recursion in the CMMCorePlus init
         from ..core import CMMCorePlus
 
-        mmc = CMMCorePlus.instance()
+        mmc = self._mmc or CMMCorePlus.instance()
         self._events.sequenceStarted.emit(sequence)
         logger.info("MDA Started: {}", sequence)
         self._paused = False

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -140,4 +140,5 @@ class MDAEngine(PMDAEngine):
             self._events.frameReady.emit(img, event)
 
         logger.info("MDA Finished: {}", sequence)
+        self._running = False
         self._events.sequenceFinished.emit(sequence)

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -19,6 +19,10 @@ class PMDAEngine(Protocol):
         """Return the MDA events object."""
 
     @abstractmethod
+    def is_running(self) -> bool:
+        """Return whether currently running an Acquistion"""
+
+    @abstractmethod
     def cancel(self):
         """Cancel the MDA."""
 
@@ -41,13 +45,18 @@ class MDAEngine(PMDAEngine):
         self._events = _get_auto_MDA_callback_class()()
         self._canceled = False
         self._paused = False
+        self._running = False
 
     @property
     def events(self) -> PMDASignaler:
         return self._events
 
+    def is_running(self) -> bool:
+        return self._running
+
     def cancel(self):
         self._canceled = True
+        self._running = False
 
     def toggle_pause(self):
         self._paused = not self._paused
@@ -57,6 +66,7 @@ class MDAEngine(PMDAEngine):
         return self._paused
 
     def run(self, sequence: MDASequence) -> None:
+        self._running = True
         # instancing here rather than in init to avoid
         # recursion in the CMMCorePlus init
         from ..core import CMMCorePlus

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -1,14 +1,11 @@
 import time
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from loguru import logger
 from useq import MDASequence
 
 from .events import PMDASignaler, _get_auto_MDA_callback_class
-
-if TYPE_CHECKING:
-    from ..core import CMMCorePlus
 
 
 @runtime_checkable
@@ -16,7 +13,7 @@ class PMDAEngine(Protocol):
     @property
     @abstractmethod
     def events(self) -> PMDASignaler:
-        """Returns the signaler object."""
+        """Return the MDA events object."""
         ...
 
     @abstractmethod
@@ -46,6 +43,7 @@ class MDAEngine(PMDAEngine):
         self._canceled = False
         self._paused = False
 
+    @property
     def events(self) -> PMDASignaler:
         return self._events
 
@@ -62,6 +60,8 @@ class MDAEngine(PMDAEngine):
     def run(self, sequence: MDASequence) -> None:
         # instancing here rather than in init to avoid
         # recursion in the CMMCorePlus init
+        from ..core import CMMCorePlus
+
         mmc = CMMCorePlus.instance()
         self._events.sequenceStarted.emit(sequence)
         logger.info("MDA Started: {}", sequence)

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -17,27 +17,22 @@ class PMDAEngine(Protocol):
     @abstractmethod
     def events(self) -> PMDASignaler:
         """Return the MDA events object."""
-        ...
 
     @abstractmethod
     def cancel(self):
         """Cancel the MDA."""
-        ...
 
     @abstractmethod
     def toggle_pause(self):
         """Switch whether the MDA is paused."""
-        ...
 
     @abstractmethod
     def is_paused(self) -> bool:
         """Returns whether the acquistion is currently paused."""
-        ...
 
     @abstractmethod
     def run(self, sequence: MDASequence):
         """Start the acquisition loop blocking the current thread."""
-        ...
 
 
 class MDAEngine(PMDAEngine):

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -1,4 +1,5 @@
 import time
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from loguru import logger
@@ -12,15 +13,30 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class PMDAEngine(Protocol):
-    events: PMDASignaler
+    @property
+    @abstractmethod
+    def events(self) -> PMDASignaler:
+        """Returns the signaler object."""
+        ...
 
+    @abstractmethod
     def cancel(self):
+        """Cancel the MDA."""
         ...
 
+    @abstractmethod
     def toggle_pause(self):
+        """Switch whether the MDA is paused."""
         ...
 
+    @abstractmethod
+    def is_paused(self) -> bool:
+        """Returns whether the acquistion is currently paused."""
+        ...
+
+    @abstractmethod
     def run(self, sequence: MDASequence):
+        """Start the acquisition loop blocking the current thread."""
         ...
 
 

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -1,0 +1,113 @@
+import time
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from loguru import logger
+from useq import MDASequence
+
+from .events import PMDASignaler, _get_auto_MDA_callback_class
+
+if TYPE_CHECKING:
+    from ..core import CMMCorePlus
+
+
+@runtime_checkable
+class PMDAEngine(Protocol):
+    events: PMDASignaler
+
+    def cancel(self):
+        ...
+
+    def toggle_pause(self):
+        ...
+
+    def run(self, sequence: MDASequence):
+        ...
+
+
+class MDAEngine:
+    def __init__(self, mmc: "CMMCorePlus") -> None:
+        self.events = _get_auto_MDA_callback_class()()
+        # we can't use the Instance approach here
+        # because this will be called from the init of CMMCorePlus
+        # which means that no instance exists yet and then... badness
+        self._mmc = mmc
+        self._canceled = False
+        self._paused = False
+
+    def cancel(self):
+        self._canceled = True
+
+    def toggle_pause(self):
+        self._paused = not self._paused
+        self.events.sequencePauseToggled.emit(self._paused)
+
+    def run(self, sequence: MDASequence) -> None:
+        self.events.sequenceStarted.emit(sequence)
+        logger.info("MDA Started: {}", sequence)
+        self._paused = False
+        paused_time = 0.0
+        t0 = time.perf_counter()  # reference time, in seconds
+
+        def check_canceled():
+            if self._canceled:
+                logger.warning("MDA Canceled: {}", sequence)
+                self.events.sequenceCanceled.emit(sequence)
+                self._canceled = False
+                return True
+            return False
+
+        for event in sequence:
+            while self._paused and not self._canceled:
+                paused_time += 0.1  # fixme: be more precise
+                time.sleep(0.1)
+
+            if check_canceled():
+                break
+
+            if event.min_start_time:
+                go_at = event.min_start_time + paused_time
+                # We need to enter a loop here checking paused and canceled.
+                # otherwise you'll potentially wait a long time to cancel
+                to_go = go_at - (time.perf_counter() - t0)
+                while to_go > 0:
+                    while self._paused and not self._canceled:
+                        paused_time += 0.1  # fixme: be more precise
+                        to_go += 0.1
+                        time.sleep(0.1)
+
+                    if self._canceled:
+                        break
+                    if to_go > 0.5:
+                        time.sleep(0.5)
+                    else:
+                        time.sleep(to_go)
+                    to_go = go_at - (time.perf_counter() - t0)
+
+            # check canceled again in case it was canceled
+            # during the waiting loop
+            if check_canceled():
+                break
+
+            logger.info(event)
+
+            # prep hardware
+            if event.x_pos is not None or event.y_pos is not None:
+                x = event.x_pos or self._mmc.getXPosition()
+                y = event.y_pos or self._mmc.getYPosition()
+                self._mmc.setXYPosition(x, y)
+            if event.z_pos is not None:
+                self._mmc.setZPosition(event.z_pos)
+            if event.channel is not None:
+                self._mmc.setConfig(event.channel.group, event.channel.config)
+            if event.exposure is not None:
+                self._mmc.setExposure(event.exposure)
+
+            # acquire
+            self._mmc.waitForSystem()
+            self._mmc.snapImage()
+            img = self._mmc.getImage()
+
+            self.events.frameReady.emit(img, event)
+
+        logger.info("MDA Finished: {}", sequence)
+        self.events.sequenceFinished.emit(sequence)

--- a/pymmcore_plus/mda/events/__init__.py
+++ b/pymmcore_plus/mda/events/__init__.py
@@ -1,0 +1,38 @@
+from ..._util import _check_qt
+from ._protocol import PMDASignaler
+from ._psygnal import MDASignaler
+
+__all__ = [
+    "PMDASignaler",
+    "MDASignaler",
+    "QMDASignaler",
+    "_get_auto_MDA_callback_class",
+]
+
+
+def _get_auto_MDA_callback_class(default=MDASignaler):
+    if _check_qt():
+        print("here?")
+        from ._qsignals import QMDASignaler
+
+        return QMDASignaler
+
+    return default
+
+
+def __dir__():
+    return list(globals()) + ["QMDASignaler"]
+
+
+def __getattr__(name: str):
+    if name == "QMDASignaler":
+        try:
+            from ._qsignals import QMDASignaler
+
+            return QMDASignaler
+        except ImportError as e:
+            raise ImportError(
+                f"{e}.\nQMDASignaler requires qtpy and either PySide2 or PyQt5.`"
+            ) from e
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pymmcore_plus/mda/events/__init__.py
+++ b/pymmcore_plus/mda/events/__init__.py
@@ -1,4 +1,4 @@
-from ..._util import _check_qt
+from ..._util import _qt_app_is_running
 from ._protocol import PMDASignaler
 from ._psygnal import MDASignaler
 
@@ -11,8 +11,7 @@ __all__ = [
 
 
 def _get_auto_MDA_callback_class(default=MDASignaler):
-    if _check_qt():
-        print("here?")
+    if _qt_app_is_running():
         from ._qsignals import QMDASignaler
 
         return QMDASignaler

--- a/pymmcore_plus/mda/events/_protocol.py
+++ b/pymmcore_plus/mda/events/_protocol.py
@@ -1,0 +1,22 @@
+from typing import Any, Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class PSignalInstance(Protocol):
+    def connect(self, slot: Callable, **kwargs: Any):
+        ...
+
+    def disconnect(self, slot: Callable, **kwargs: Any):
+        ...
+
+    def emit(self, args: Any):
+        ...
+
+
+@runtime_checkable
+class PMDASignaler(Protocol):
+    sequenceStarted: PSignalInstance
+    sequencePauseToggled: PSignalInstance
+    sequenceCanceled: PSignalInstance
+    sequenceFinished: PSignalInstance
+    frameReady: PSignalInstance

--- a/pymmcore_plus/mda/events/_psygnal.py
+++ b/pymmcore_plus/mda/events/_psygnal.py
@@ -1,0 +1,11 @@
+import numpy as np
+from psygnal import Signal
+from useq import MDAEvent, MDASequence
+
+
+class MDASignaler:
+    sequenceStarted = Signal(MDASequence)  # at the start of an MDA sequence
+    sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
+    sequenceCanceled = Signal(MDASequence)  # when mda is canceled
+    sequenceFinished = Signal(MDASequence)  # when mda is done (whether canceled or not)
+    frameReady = Signal(np.ndarray, MDAEvent)  # after each event in the sequence

--- a/pymmcore_plus/mda/events/_qsignals.py
+++ b/pymmcore_plus/mda/events/_qsignals.py
@@ -1,0 +1,9 @@
+from qtpy.QtCore import QObject, Signal
+
+
+class QMDASignaler(QObject):
+    sequenceStarted = Signal(object)  # at the start of an MDA sequence
+    sequencePauseToggled = Signal(bool)  # when MDA is paused/unpaused
+    sequenceCanceled = Signal(object)  # when mda is canceled
+    sequenceFinished = Signal(object)  # when mda is done (whether canceled or not)
+    frameReady = Signal(object, object)  # after each event in the sequence

--- a/pymmcore_plus/remote/_tests/test_client.py
+++ b/pymmcore_plus/remote/_tests/test_client.py
@@ -21,6 +21,7 @@ def test_client(proxy):
     proxy.getConfigGroupState("Channel")
 
 
+@pytest.mark.skip(reason="mda not being properly exposed")
 def test_mda(qtbot, proxy):
     mda = MDASequence(time_plan={"interval": 0.1, "loops": 2})
 
@@ -54,6 +55,7 @@ def test_mda(qtbot, proxy):
 
 
 # test canceling while waiting for the next time point
+@pytest.mark.skip(reason="mda not being properly exposed")
 def test_mda_cancel(qtbot, proxy: RemoteMMCore):
     mda = MDASequence(time_plan={"interval": 5000, "loops": 3})
     with qtbot.waitSignal(proxy.events.sequenceStarted):


### PR DESCRIPTION
As discussed in: https://github.com/tlambert03/pymmcore-plus/issues/101
Not polished yet - Opening for feedback from @tlambert03 

The big thing I struggled with was the relationship between core and the mda object should be. The mda engine needs to have access to core methods in order to function but then you can end up with this awful thing: `core._mda_engine._mmc._mda_engine._mmc.....`


If we decide to got this way then this should also get:
1. update the client to reflect the new structure.
2. Start of an `mda_tests` file
3. add an example showing how to define your own MDA engine.