### PR TITLE
Fix event emission when setting property on a state device

### DIFF
--- a/pymmcore_plus/_tests/conftest.py
+++ b/pymmcore_plus/_tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+import pymmcore_plus
+
+
+@pytest.fixture(params=["QSignal", "psygnal"], scope="function")
+def core(request):
+    core = pymmcore_plus.CMMCorePlus()
+    if request.param == "psygnal":
+        core.events = pymmcore_plus.CMMCoreSignaler()
+        core._callback_relay = pymmcore_plus.core._mmcore_plus.MMCallbackRelay(
+            core.events
+        )
+        core.registerCallback(core._callback_relay)
+    if not core.getDeviceAdapterSearchPaths():
+        pytest.fail(
+            "To run tests, please install MM with `python -m pymmcore_plus.install`"
+        )
+    core.loadSystemConfiguration()
+    return core

--- a/pymmcore_plus/_tests/test_events.py
+++ b/pymmcore_plus/_tests/test_events.py
@@ -1,5 +1,8 @@
+from unittest.mock import Mock, call
+
 import pytest
 
+from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.core.events import CMMCoreSignaler, PCoreSignaler, QCoreSignaler
 
 
@@ -19,3 +22,72 @@ def test_events_protocols(cls):
             raise AssertionError(
                 f"'{name}.{attr}' expected type {value.__name__!r}, got {type(m)}"
             )
+
+
+def test_set_property_events(core: CMMCorePlus):
+    """Test that using setProperty always emits a propertyChanged event."""
+    mock = Mock()
+    core.events.propertyChanged.connect(mock)
+    core.setProperty("Camera", "Binning", "2")
+    mock.assert_called_once_with("Camera", "Binning", "2")
+
+    mock.reset_mock()
+    core.setProperty("Camera", "Binning", "1")
+    mock.assert_called_once_with("Camera", "Binning", "1")
+
+    mock.reset_mock()
+    core.setProperty("Camera", "Binning", "1")
+    mock.assert_not_called()  # value didn't change
+
+    # this is not a property that the DemoCamera emits...
+    # so with regular pymmcore, this would not be emitted.
+    core.setProperty("Camera", "AllowMultiROI", "1")
+    mock.assert_called_once_with("Camera", "AllowMultiROI", "1")
+
+
+def test_set_state_events(core: CMMCorePlus):
+    mock = Mock()
+    core.events.propertyChanged.connect(mock)
+    assert core.getState("Objective") == 1
+    core.setState("Objective", 3)
+    mock.assert_has_calls(
+        [
+            call("Objective", "State", "3"),
+            call("Objective", "Label", "Nikon 20X Plan Fluor ELWD"),
+        ]
+    )
+    assert core.getState("Objective") == 3
+
+    mock.reset_mock()
+    assert core.getState("Dichroic") == 0
+    core.setStateLabel("Dichroic", "Q505LP")
+    mock.assert_has_calls(
+        [call("Dichroic", "State", "1"), call("Dichroic", "Label", "Q505LP")]
+    )
+    assert core.getState("Dichroic") == 1
+
+
+def test_set_statedevice_property_emits_events(core: CMMCorePlus):
+    mock = Mock()
+    core.events.propertyChanged.connect(mock)
+    assert core.getState("Objective") == 1
+    assert core.getProperty("Objective", "State") == "1"
+    core.setProperty("Objective", "State", "3")
+    mock.assert_has_calls(
+        [
+            call("Objective", "State", "3"),
+            call("Objective", "Label", "Nikon 20X Plan Fluor ELWD"),
+        ]
+    )
+    assert core.getState("Objective") == 3
+    assert core.getProperty("Objective", "State") == "3"
+    assert core.getProperty("Objective", "Label") == "Nikon 20X Plan Fluor ELWD"
+
+    mock.reset_mock()
+    assert core.getProperty("Dichroic", "Label") == "400DCLP"
+    core.setProperty("Dichroic", "Label", "Q505LP")
+    mock.assert_has_calls(
+        [call("Dichroic", "State", "1"), call("Dichroic", "Label", "Q505LP")]
+    )
+    assert core.getProperty("Dichroic", "Label") == "Q505LP"
+    assert core.getProperty("Dichroic", "State") == "1"

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -636,6 +636,14 @@ class CMMCorePlus(pymmcore.CMMCore):
             a sequence of property names to monitor
         """
 
+        # make sure that changing either state device property emits both signals
+        if (
+            len(properties) == 1
+            and properties[0] in {"State", "Label"}
+            and self.getDeviceType(device) is DeviceType.StateDevice
+        ):
+            properties = ("State", "Label")
+
         before = [self.getProperty(device, p) for p in properties]
         with _blockSignal(self.events, self.events.propertyChanged):
             yield


### PR DESCRIPTION
fixes #104

also creates and moves some tests.  The only new thing in the PR is the 6 lines in _mmcore_plus