### PR TITLE
use better globals for State and Label

### DIFF
--- a/pymmcore_plus/_tests/test_events.py
+++ b/pymmcore_plus/_tests/test_events.py
@@ -1,6 +1,8 @@
 from unittest.mock import Mock, call
 
 import pytest
+from pymmcore import g_Keyword_Label as LABEL
+from pymmcore import g_Keyword_State as STATE
 
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.core.events import CMMCoreSignaler, PCoreSignaler, QCoreSignaler
@@ -52,8 +54,8 @@ def test_set_state_events(core: CMMCorePlus):
     core.setState("Objective", 3)
     mock.assert_has_calls(
         [
-            call("Objective", "State", "3"),
-            call("Objective", "Label", "Nikon 20X Plan Fluor ELWD"),
+            call("Objective", STATE, "3"),
+            call("Objective", LABEL, "Nikon 20X Plan Fluor ELWD"),
         ]
     )
     assert core.getState("Objective") == 3
@@ -62,7 +64,7 @@ def test_set_state_events(core: CMMCorePlus):
     assert core.getState("Dichroic") == 0
     core.setStateLabel("Dichroic", "Q505LP")
     mock.assert_has_calls(
-        [call("Dichroic", "State", "1"), call("Dichroic", "Label", "Q505LP")]
+        [call("Dichroic", STATE, "1"), call("Dichroic", LABEL, "Q505LP")]
     )
     assert core.getState("Dichroic") == 1
 
@@ -71,23 +73,23 @@ def test_set_statedevice_property_emits_events(core: CMMCorePlus):
     mock = Mock()
     core.events.propertyChanged.connect(mock)
     assert core.getState("Objective") == 1
-    assert core.getProperty("Objective", "State") == "1"
-    core.setProperty("Objective", "State", "3")
+    assert core.getProperty("Objective", STATE) == "1"
+    core.setProperty("Objective", STATE, "3")
     mock.assert_has_calls(
         [
-            call("Objective", "State", "3"),
-            call("Objective", "Label", "Nikon 20X Plan Fluor ELWD"),
+            call("Objective", STATE, "3"),
+            call("Objective", LABEL, "Nikon 20X Plan Fluor ELWD"),
         ]
     )
     assert core.getState("Objective") == 3
-    assert core.getProperty("Objective", "State") == "3"
-    assert core.getProperty("Objective", "Label") == "Nikon 20X Plan Fluor ELWD"
+    assert core.getProperty("Objective", STATE) == "3"
+    assert core.getProperty("Objective", LABEL) == "Nikon 20X Plan Fluor ELWD"
 
     mock.reset_mock()
-    assert core.getProperty("Dichroic", "Label") == "400DCLP"
-    core.setProperty("Dichroic", "Label", "Q505LP")
+    assert core.getProperty("Dichroic", LABEL) == "400DCLP"
+    core.setProperty("Dichroic", LABEL, "Q505LP")
     mock.assert_has_calls(
-        [call("Dichroic", "State", "1"), call("Dichroic", "Label", "Q505LP")]
+        [call("Dichroic", STATE, "1"), call("Dichroic", LABEL, "Q505LP")]
     )
-    assert core.getProperty("Dichroic", "Label") == "Q505LP"
-    assert core.getProperty("Dichroic", "State") == "1"
+    assert core.getProperty("Dichroic", LABEL) == "Q505LP"
+    assert core.getProperty("Dichroic", STATE) == "1"

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -48,6 +48,10 @@ _OBJECTIVE_DEVICE_RE = re.compile(
 )
 _CHANNEL_REGEX = re.compile("(chan{1,2}(el)?|filt(er)?)s?", re.IGNORECASE)
 
+STATE = pymmcore.g_Keyword_State
+LABEL = pymmcore.g_Keyword_Label
+STATE_PROPS = (STATE, LABEL)
+
 
 @contextmanager
 def _blockSignal(obj, signal):
@@ -119,17 +123,13 @@ class CMMCorePlus(pymmcore.CMMCore):
     @synchronized(lock)
     def setState(self, stateDeviceLabel: str, state: int) -> None:
         """Set state (by position) on stateDeviceLabel, with reliable event emission."""
-        with self._property_change_emission_ensured(
-            stateDeviceLabel, ("State", "Label")
-        ):
+        with self._property_change_emission_ensured(stateDeviceLabel, STATE_PROPS):
             super().setState(stateDeviceLabel, state)
 
     @synchronized(lock)
     def setStateLabel(self, stateDeviceLabel: str, stateLabel: str) -> None:
         """Set state (by label) on stateDeviceLabel, with reliable event emission."""
-        with self._property_change_emission_ensured(
-            stateDeviceLabel, ("State", "Label")
-        ):
+        with self._property_change_emission_ensured(stateDeviceLabel, STATE_PROPS):
             super().setStateLabel(stateDeviceLabel, stateLabel)
 
     def setDeviceAdapterSearchPaths(self, adapter_paths: ListOrTuple[str]) -> None:
@@ -639,10 +639,10 @@ class CMMCorePlus(pymmcore.CMMCore):
         # make sure that changing either state device property emits both signals
         if (
             len(properties) == 1
-            and properties[0] in {"State", "Label"}
+            and properties[0] in STATE_PROPS
             and self.getDeviceType(device) is DeviceType.StateDevice
         ):
-            properties = ("State", "Label")
+            properties = STATE_PROPS
 
         before = [self.getProperty(device, p) for p in properties]
         with _blockSignal(self.events, self.events.propertyChanged):


### PR DESCRIPTION
uses pymmcore.g_keywords instead of strings for State and Label