### PR TITLE
Adds MMProperty class - a view onto a core property with a nicer API

### DIFF
--- a/pymmcore_plus/__init__.py
+++ b/pymmcore_plus/__init__.py
@@ -5,7 +5,7 @@ except ImportError:  # pragma: no cover
 
 from typing import TYPE_CHECKING
 
-from ._util import find_micromanager
+from ._util import find_micromanager, iter_device_props
 from .core import (
     ActionType,
     CMMCorePlus,
@@ -15,6 +15,7 @@ from .core import (
     DeviceType,
     FocusDirection,
     Metadata,
+    MMProperty,
     PortType,
     PropertyType,
 )
@@ -26,16 +27,17 @@ if TYPE_CHECKING:
 __all__ = [
     "ActionType",
     "CMMCorePlus",
-    "CMMCorePlus",
     "CMMCoreSignaler",
     "Configuration",
-    "PCoreSignaler",
     "DeviceDetectionStatus",
     "DeviceNotification",
     "DeviceType",
     "find_micromanager",
     "FocusDirection",
+    "iter_device_props",
     "Metadata",
+    "MMProperty",
+    "PCoreSignaler",
     "PortType",
     "PropertyType",
     "RemoteMMCore",

--- a/pymmcore_plus/_tests/test_property_class.py
+++ b/pymmcore_plus/_tests/test_property_class.py
@@ -1,0 +1,8 @@
+from pymmcore_plus import CMMCorePlus, MMProperty, iter_device_props
+
+
+def test_mmproperty(core: CMMCorePlus):
+    for dp in iter_device_props(core):
+        prop = MMProperty(*dp, mmcore=core)
+        assert prop.isValid()
+        assert prop.dict()

--- a/pymmcore_plus/_util.py
+++ b/pymmcore_plus/_util.py
@@ -2,7 +2,9 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional, Tuple
+
+from pymmcore import CMMCore
 
 camel_to_snake = re.compile(r"(?<!^)(?=[A-Z])")
 
@@ -58,3 +60,26 @@ def _qt_app_is_running() -> bool:
             QtWidgets = getattr(qmodule, "QtWidgets")
             return QtWidgets.QApplication.instance() is not None
     return False
+
+
+def iter_device_props(mmcore: Optional[CMMCore] = None) -> Iterator[Tuple[str, str]]:
+    """Yield all pairs of currently loaded (device_label, property_name).
+
+    Parameters
+    ----------
+    mmcore : Optional[CMMCore]
+        MMCore instance. If `None` (the default), will use the global
+        CMMCorePlus.instance()
+
+    Yields
+    ------
+    Iterator[Tuple[str, str]]
+        Pairs of loaded (device_label, property_name) tuples.
+    """
+    if not mmcore:
+        from pymmcore_plus import CMMCorePlus
+
+        mmcore = CMMCorePlus.instance()
+    for dev in mmcore.getLoadedDevices():
+        for prop in mmcore.getDevicePropertyNames(dev):
+            yield dev, prop

--- a/pymmcore_plus/core/__init__.py
+++ b/pymmcore_plus/core/__init__.py
@@ -1,14 +1,15 @@
 __all__ = [
+    "ActionType",
     "CMMCorePlus",
     "Configuration",
-    "Metadata",
-    "DeviceType",
-    "PropertyType",
-    "ActionType",
-    "PortType",
-    "FocusDirection",
-    "DeviceNotification",
     "DeviceDetectionStatus",
+    "DeviceNotification",
+    "DeviceType",
+    "FocusDirection",
+    "Metadata",
+    "MMProperty",
+    "PortType",
+    "PropertyType",
 ]
 
 from ._config import Configuration
@@ -23,3 +24,4 @@ from ._constants import (
 )
 from ._metadata import Metadata
 from ._mmcore_plus import CMMCorePlus
+from ._property import MMProperty

--- a/pymmcore_plus/core/_property.py
+++ b/pymmcore_plus/core/_property.py
@@ -1,0 +1,145 @@
+from typing import Any, Optional, Tuple
+
+from pymmcore import g_Keyword_Label, g_Keyword_State
+
+from ._constants import DeviceType, PropertyType
+from ._mmcore_plus import CMMCorePlus
+
+
+class MMProperty:
+    """Convenience "View" onto a device property.
+
+    Parameters
+    ----------
+    device_label : str
+        Device this property belongs to
+    property_name : str
+        Name of this property
+    mmcore : Optional[CMMCorePlus]
+        CMMCore instance, by default global singleton.
+
+    Examples
+    --------
+
+    >>> prop = MMProperty('Objective', 'Label')
+    >>> prop.dict()
+    >>> prop.core.loadSystemConfiguration()
+    >>> prop.dict()
+    >>> prop.value
+    >>> prop.value = 'Objective-2'
+    >>> prop.isReadOnly()
+    >>> prop.hasLimits()
+    >>> prop.range()
+    ...
+    """
+
+    def __init__(
+        self,
+        device_label: str,
+        property_name: str,
+        *,
+        mmcore: Optional[CMMCorePlus] = None,
+    ) -> None:
+
+        self.device = device_label
+        self.name = property_name
+        self._mmc = mmcore or CMMCorePlus.instance()
+
+    def isValid(self) -> bool:
+        return self.isLoaded() and self._mmc.hasProperty(self.device, self.name)
+
+    def isLoaded(self) -> bool:
+        return self._mmc is not None and self.device in self._mmc.getLoadedDevices()
+
+    @property
+    def core(self) -> CMMCorePlus:
+        return self._mmc
+
+    @core.setter
+    def core(self, mmcore: CMMCorePlus) -> None:
+        self._mmc = mmcore
+
+    # functional alternate to property setter
+    def setCore(self, mmcore: CMMCorePlus) -> None:
+        self._mmc = mmcore
+
+    @property
+    def value(self) -> Any:
+        """Return value, cast to appropriate type if applicable."""
+        v = self._mmc.getProperty(self.device, self.name)
+        if type_ := self.type().to_python():
+            v = type_(v)
+        return v
+
+    @value.setter
+    def value(self, val: Any) -> None:
+        self.setValue(val)
+
+    # functional alternate to property setter
+    def setValue(self, val: Any) -> None:
+        if self.isReadOnly():
+            import warnings
+
+            warnings.warn(f"'{self.device}::{self.name}' is a read-only property.")
+        self._mmc.setProperty(self.device, self.name, val)
+
+    def isReadOnly(self) -> bool:
+        return self._mmc.isPropertyReadOnly(self.device, self.name)
+
+    def isPreInit(self) -> bool:
+        return self._mmc.isPropertyPreInit(self.device, self.name)
+
+    def hasLimits(self) -> bool:
+        return self._mmc.hasPropertyLimits(self.device, self.name)
+
+    def lowerLimit(self) -> float:
+        return self._mmc.getPropertyLowerLimit(self.device, self.name)
+
+    def upperLimit(self) -> float:
+        return self._mmc.getPropertyUpperLimit(self.device, self.name)
+
+    def range(self) -> Tuple[float, float]:
+        return (self.lowerLimit(), self.upperLimit())
+
+    def type(self) -> PropertyType:
+        return self._mmc.getPropertyType(self.device, self.name)
+
+    def deviceType(self) -> DeviceType:
+        return self._mmc.getDeviceType(self.device)
+
+    def allowedValues(self) -> Tuple[str, ...]:
+        # https://github.com/micro-manager/mmCoreAndDevices/issues/172
+        allowed = self._mmc.getAllowedPropertyValues(self.device, self.name)
+        if not allowed and self.deviceType() is DeviceType.StateDevice:
+            if self.name == g_Keyword_State:
+                n_states = self._mmc.getNumberOfStates(self.device)
+                allowed = tuple(str(i) for i in range(n_states))
+            elif self.name == g_Keyword_Label:
+                allowed = self._mmc.getStateLabels(self.device)
+        return allowed
+
+    def dict(self) -> dict:
+        d = {
+            "valid": self.isValid(),
+            "value": None,
+            "type": None,
+            "device_type": None,
+            "read_only": None,
+            "pre_init": None,
+            "range": None,
+            "allowed": None,
+        }
+
+        if d["valid"]:
+            d["value"] = self.value
+            d["type"] = self.type().to_json()
+            d["device_type"] = self.deviceType().name
+            d["read_only"] = self.isReadOnly()
+            d["pre_init"] = self.isPreInit()
+            d["range"] = self.range() if self.hasLimits() else None
+            d["allowed"] = self.allowedValues()
+        return d
+
+    def __repr__(self) -> str:
+        v = f"value={self.value!r}" if self.isValid() else "INVALID"
+        return f"<Property {self.name} on device {self.device}: {v}>"


### PR DESCRIPTION
this is a convenience class that lets you avoid doing a lot of searching for the property related API on the core object.

```python
In [1]: from pymmcore_plus import MMProperty

In [2]: prop = MMProperty('Objective', 'Label')

In [3]: prop.isValid()  # doesn't need to be loaded in core
Out[3]: False

In [4]: prop.core.loadSystemConfiguration()

In [5]: prop.isValid()  # now it's loaded in core
Out[5]: True

In [6]: prop.value
Out[6]: 'Nikon 10X S Fluor'

In [7]: prop.value = 'Objective-2'  # property.setter

In [8]: prop.value
Out[8]: 'Objective-2'

In [9]: prop.value == prop.core.getProperty(prop.device, prop.name)  # stays in sync
Out[9]: True

In [10]: prop.isReadOnly()
Out[10]: False

In [11]: prop.hasLimits()
Out[11]: False

In [12]: prop.type()
Out[12]: <PropertyType.String: 1>

In [13]: prop  # nice repr
Out[13]: <Property Label on device Objective: value='Objective-2'>
```