### PR TITLE
reconfigure MDAEngine to make it easier to subclass

### DIFF
--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -240,7 +240,8 @@ def test_not_concurrent_mdas(core, qtbot: "QtBot"):
         z_plan={"range": 3, "step": 1},
         channels=[{"config": "DAPI", "exposure": 1}],
     )
-    core.run_mda(mda)
+    with qtbot.waitSignal(core.mda.events.sequenceStarted):
+        core.run_mda(mda)
     assert core.mda.is_running()
     with pytest.raises(ValueError):
         core.run_mda(mda)

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -84,10 +84,12 @@ class MDAEngine(PMDAEngine):
         Toggle the paused state of the current acquisition.
 
         To get whether the acquisition is currently paused use the
-        ``is_paused`` method.
+        ``is_paused`` method. This method is a no-op if no acquistion is
+        currently underway.
         """
-        self._paused = not self._paused
-        self._events.sequencePauseToggled.emit(self._paused)
+        if self._running:
+            self._paused = not self._paused
+            self._events.sequencePauseToggled.emit(self._paused)
 
     def is_paused(self) -> bool:
         """

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from loguru import logger
-from useq import MDASequence
+from useq import MDAEvent, MDASequence
 
 from .events import PMDASignaler, _get_auto_MDA_callback_class
 
@@ -56,7 +56,8 @@ class MDAEngine(PMDAEngine):
 
     def cancel(self):
         self._canceled = True
-        self._running = False
+        self._paused_time = 0
+        self._t0 = None
 
     def toggle_pause(self):
         self._paused = not self._paused
@@ -65,43 +66,81 @@ class MDAEngine(PMDAEngine):
     def is_paused(self) -> bool:
         return self._paused
 
-    def run(self, sequence: MDASequence) -> None:
+    def _prepare_to_run(self, sequence: MDASequence):
+        """
+        Set up for the MDA run - defining private variables and emitting sequenceStarted
+
+        Parameters
+        ----------
+        sequence : MDASequence
+        """
         self._running = True
         # instancing here rather than in init to avoid
         # recursion in the CMMCorePlus init
         from ..core import CMMCorePlus
 
-        mmc = self._mmc or CMMCorePlus.instance()
+        self._mmc = self._mmc or CMMCorePlus.instance()
         self._events.sequenceStarted.emit(sequence)
+        self._sequence = sequence
         logger.info("MDA Started: {}", sequence)
         self._paused = False
-        paused_time = 0.0
-        t0 = time.perf_counter()  # reference time, in seconds
+        self._paused_time = 0.0
+        self._t0 = time.perf_counter()  # reference time, in seconds
 
-        def check_canceled():
-            if self._canceled:
-                logger.warning("MDA Canceled: {}", sequence)
-                self._events.sequenceCanceled.emit(sequence)
-                self._canceled = False
+    def _check_canceled(self) -> bool:
+        """
+        Check if the cancel() method has been called and emit relevant signals.
+
+        If cancelled this relies on the self._sequence being the current sequence
+        in order to emit a sequenceCanceled signal.
+
+        Returns
+        -------
+        bool
+            Whether the MDA has been canceled.
+
+        """
+        if self._canceled:
+            logger.warning("MDA Canceled: {}", self._sequence)
+            self._events.sequenceCanceled.emit(self._sequence)
+            self._canceled = False
+            return True
+        return False
+
+    def _wait_until_event(self, event: MDAEvent, sequence: MDASequence) -> bool:
+        """
+        Wait until the event's min start time, checking for pauses
+        cancelations.
+
+        Parameters
+        ----------
+        event : MDAEvent
+        sequence : MDASequence
+
+        Returns
+        -------
+        bool
+            Whether the MDA was cancelled while waiting.
+        """
+        if not self._running:
+            return
+        if self._check_canceled():
+            return True
+        while self._paused and not self._canceled:
+            self._paused_time += 0.1  # fixme: be more precise
+            time.sleep(0.1)
+
+            if self._check_canceled():
                 return True
-            return False
-
-        for event in sequence:
-            while self._paused and not self._canceled:
-                paused_time += 0.1  # fixme: be more precise
-                time.sleep(0.1)
-
-            if check_canceled():
-                break
 
             if event.min_start_time:
-                go_at = event.min_start_time + paused_time
+                go_at = event.min_start_time + self._paused_time
                 # We need to enter a loop here checking paused and canceled.
                 # otherwise you'll potentially wait a long time to cancel
-                to_go = go_at - (time.perf_counter() - t0)
+                to_go = go_at - (time.perf_counter() - self._t0)
                 while to_go > 0:
                     while self._paused and not self._canceled:
-                        paused_time += 0.1  # fixme: be more precise
+                        self._paused_time += 0.1  # fixme: be more precise
                         to_go += 0.1
                         time.sleep(0.1)
 
@@ -111,34 +150,69 @@ class MDAEngine(PMDAEngine):
                         time.sleep(0.5)
                     else:
                         time.sleep(to_go)
-                    to_go = go_at - (time.perf_counter() - t0)
+                    to_go = go_at - (time.perf_counter() - self._t0)
 
-            # check canceled again in case it was canceled
-            # during the waiting loop
-            if check_canceled():
-                break
+        # check canceled again in case it was canceled
+        # during the waiting loop
+        if self._check_canceled():
+            return True
+        return False
 
-            logger.info(event)
+    def _prep_hardware(self, event: MDAEvent, waitForSystem: bool = True):
+        """
+        Set the system hardware (XY, Z, channel, exposure) as defined in the event.
 
-            # prep hardware
-            if event.x_pos is not None or event.y_pos is not None:
-                x = event.x_pos or mmc.getXPosition()
-                y = event.y_pos or mmc.getYPosition()
-                mmc.setXYPosition(x, y)
-            if event.z_pos is not None:
-                mmc.setZPosition(event.z_pos)
-            if event.channel is not None:
-                mmc.setConfig(event.channel.group, event.channel.config)
-            if event.exposure is not None:
-                mmc.setExposure(event.exposure)
+        Parameters
+        ----------
+        event : MDAEvent
+            The event to use for the Hardware config
+        waitForSystem : bool
+            Whether to call `core.waitForSystem()`
+        """
+        if not self._running:
+            return
+        if event.x_pos is not None or event.y_pos is not None:
+            x = event.x_pos or self._mmc.getXPosition()
+            y = event.y_pos or self._mmc.getYPosition()
+            self._mmc.setXYPosition(x, y)
+        if event.z_pos is not None:
+            self._mmc.setZPosition(event.z_pos)
+        if event.channel is not None:
+            self._mmc.setConfig(event.channel.group, event.channel.config)
+        if event.exposure is not None:
+            self._mmc.setExposure(event.exposure)
 
-            # acquire
-            mmc.waitForSystem()
-            mmc.snapImage()
-            img = mmc.getImage()
+        if waitForSystem:
+            self._mmc.waitForSystem()
 
-            self._events.frameReady.emit(img, event)
+    def _finish_run(self, sequence: MDASequence):
+        """
+        To be called at the end of an acquisition.
 
+        Parameters
+        ----------
+        sequence : MDASequence
+            The sequence that was finished.
+        """
         logger.info("MDA Finished: {}", sequence)
         self._running = False
         self._events.sequenceFinished.emit(sequence)
+
+    def run(self, sequence: MDASequence) -> None:
+        self._prepare_to_run(sequence)
+
+        for event in sequence:
+            cancelled = self._wait_until_event(event, sequence)
+
+            # If cancelled break out of the loop
+            if cancelled:
+                break
+
+            logger.info(event)
+            self._prep_hardware(event)
+
+            self._mmc.snapImage()
+            img = self._mmc.getImage()
+
+            self._events.frameReady.emit(img, event)
+        self._finish_run(sequence)

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -52,18 +52,54 @@ class MDAEngine(PMDAEngine):
         return self._events
 
     def is_running(self) -> bool:
+        """
+        Return whether an acquistion is currently underway.
+
+        This will return True at any point between the emission of the
+        ``sequenceStarted`` and ``sequenceFinished`` signals, including when
+        the acquisition is currently paused.
+
+        Returns
+        -------
+        bool
+            Whether an acquistion is underway.
+        """
         return self._running
 
     def cancel(self):
+        """
+        Cancel the currently running acquisition.
+
+        This is a no-op if no acquisition is currently running.
+        If an acquisition is running then this will cancel the acquistion and
+        a sequenceCanceled signal, followed by a sequenceFinished signal will
+        be emitted.
+        """
         self._canceled = True
         self._paused_time = 0
         self._t0 = None
 
     def toggle_pause(self):
+        """
+        Toggle the paused state of the current acquisition.
+
+        To get whether the acquisition is currently paused use the
+        ``is_paused`` method.
+        """
         self._paused = not self._paused
         self._events.sequencePauseToggled.emit(self._paused)
 
     def is_paused(self) -> bool:
+        """
+        Return whether the acquistion is currently paused.
+
+        Use ``toggle_pause`` to change the paused state.
+
+        Returns
+        -------
+        bool
+            Whether the current acquistion is paused.
+        """
         return self._paused
 
     def _prepare_to_run(self, sequence: MDASequence):
@@ -199,6 +235,18 @@ class MDAEngine(PMDAEngine):
         self._events.sequenceFinished.emit(sequence)
 
     def run(self, sequence: MDASequence) -> None:
+        """
+        Run the multi-dimensional acquistion defined by `sequence`.
+
+        Most users should not use this directly as it will block further
+        execution. Instead use ``run_mda`` on CMMCorePlus which will run on
+        a thread.
+
+        Parameters
+        ----------
+        sequence : MDASequence
+            The sequence of events to run.
+        """
         self._prepare_to_run(sequence)
 
         for event in sequence:


### PR DESCRIPTION
This breaks up the MDAEngine `run` loop into separate methods which can be reused by subclasses. That way if all they want to do is extend some hardware stuff (like I do :) ) then they can still rely on our implementation of waiting for the next event.

The only behavior change is that the `self._running` is now set when the sequence is finished rather than immediately on cancellation. I think this behavior is more correct, but did require changing what we wait for in some of the tests.