### PR TITLE
add `setContext` method

### DIFF
--- a/docs/examples/context-set.md
+++ b/docs/examples/context-set.md
@@ -1,0 +1,16 @@
+# Set as a Context
+
+You may want to temporarily set something on core such as  `core.setAutoShutter(False)` when writing an MDA Engine. For this case
+you can use the convenience method {func}`~pymmcore_plus.CMMCorePlus.setContext`.
+
+```python
+from pymmcore_plus import CMMCorePlus
+core = CMMCorePlus.instance()
+with core.setContext(autoShutter = False):
+    assert not core.getAutoShutter()
+    # do other stuff
+
+assert core.getAutoShutter()
+```
+
+This will work for the `set` methods on the core such as `setAutoShutter`, `setShutterOpen`, ...

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,4 +43,5 @@ API <api/pymmcore_plus>
 examples/mda
 examples/integration-with-qt
 examples/napari-micromanager
+examples/context-set
 ```

--- a/pymmcore_plus/_tests/test_core.py
+++ b/pymmcore_plus/_tests/test_core.py
@@ -476,3 +476,22 @@ def test_unload_devices(core: CMMCorePlus):
     assert len(core.getLoadedDevices()) > 2
     core.unloadAllDevices()
     assert len(core.getLoadedDevices()) == 1
+
+
+def test_setContext(core: CMMCorePlus):
+    # should work with either leading capitalization
+    with core.setContext(shutterOpen=False):
+        assert not core.getShutterOpen()
+    with core.setContext(ShutterOpen=False):
+        assert not core.getShutterOpen()
+
+    # if we set an invalid value make sure initial state is still restored
+    with pytest.raises(TypeError):
+        with core.setContext(autoShutter=False, shutterOpen="sadfsd"):
+            assert not core.getAutoShutter()
+    assert core.getAutoShutter()
+
+    with pytest.raises(ValueError):
+        with core.setContext(autoShutter=False):
+            raise ValueError
+    assert core.getAutoShutter()

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -726,6 +726,28 @@ class CMMCorePlus(pymmcore.CMMCore):
             for i, val in enumerate(after):
                 self.events.propertyChanged.emit(device, properties[i], val)
 
+    @contextmanager
+    def setContext(self, **kwargs):
+        """
+        Set core properties in a context restoring the initial values on exit.
+        """
+        orig_values = {}
+        try:
+            for name, v in kwargs.items():
+                name = name[0].upper() + name[1:]
+                try:
+                    orig_values[name] = getattr(self, f"get{name}")()
+                    getattr(self, f"set{name}")(v)
+                except AttributeError:
+                    logger.warning(f"{name} is not a valid property, skipping.")
+            yield
+        finally:
+            for k, v in orig_values.items():
+                try:
+                    getattr(self, f"set{k}")(v)
+                except AttributeError:
+                    pass
+
 
 for name in (
     "getConfigData",


### PR DESCRIPTION
A reasonable extension to this (possibly to be included here) is to also allow setProperty to work. Currently it doesn't as this doesn't allow for multiple arguments.