### PR TITLE
micromanager shutter and autoshutter signals

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus, --keep-runtime-typing]

--- a/pymmcore_plus/_tests/test_events.py
+++ b/pymmcore_plus/_tests/test_events.py
@@ -118,3 +118,17 @@ def test_device_property_events(core: CMMCorePlus):
     core.setProperty("Camera", "Gain", "5")
     mock1.assert_not_called()
     mock2.assert_not_called()
+
+def test_shutter_device_events(core: CMMCorePlus):
+    mock = Mock()
+    core.events.shutterSet.connect(mock)
+    core.setShutterOpen("Shutter", True)
+    mock.assert_has_calls([call("Shutter", True),])
+    assert core.getShutterOpen("Shutter")
+
+def test_autoshutter_device_events(core: CMMCorePlus):
+    mock = Mock()
+    core.events.autoShutterSet.connect(mock)
+    core.setAutoShutter(True)
+    mock.assert_has_calls([call(True),])
+    assert core.getAutoShutter()

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -665,7 +665,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     @overload
     def setShutterOpen(self, state: bool) -> int:
-        ... # pragma: no cover
+        ...  # pragma: no cover
 
     @overload
     def setShutterOpen(self, shutterLabel: str, state: bool) -> str:

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -665,7 +665,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     @overload
     def setShutterOpen(self, state: bool) -> int:
-        ...
+        ... # pragma: no cover
 
     @overload
     def setShutterOpen(self, shutterLabel: str, state: bool) -> str:

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -662,7 +662,25 @@ class CMMCorePlus(pymmcore.CMMCore):
     def setAutoShutter(self, state: bool):
         super().setAutoShutter(state)
         self.events.autoShutterSet.emit(state)
+    
+    @overload
+    def setShutterOpen(self, state: bool) -> int:
+        ...
+    
+    @overload
+    def setShutterOpen(self, shutterLabel: str, state: bool) -> str:
+        ...
 
+    def setShutterOpen(self, *args):
+        if len(args) > 1:
+            shutterLabel, state = args
+            super().setShutterOpen(shutterLabel, state)
+        else:
+            shutterLabel = super().getShutterDevice()
+            state = args
+            super().setShutterOpen(state)
+        self.events.shutterSet.emit(shutterLabel, state)
+    
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""
         # approx retrieval cost in comment (for demoCam)
@@ -787,3 +805,4 @@ MMCallbackRelay = type(
         if n.startswith("on")
     },
 )
+

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -672,13 +672,12 @@ class CMMCorePlus(pymmcore.CMMCore):
         ...
 
     def setShutterOpen(self, *args):
+        super().setShutterOpen(*args)
         if len(args) > 1:
             shutterLabel, state = args
-            super().setShutterOpen(shutterLabel, state)
         else:
             shutterLabel = super().getShutterDevice()
             state = args
-            super().setShutterOpen(state)
         self.events.shutterSet.emit(shutterLabel, state)
     
     def state(self, exclude=()) -> dict:

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -669,7 +669,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     @overload
     def setShutterOpen(self, shutterLabel: str, state: bool) -> str:
-        ... # pragma: no cover
+        ...  # pragma: no cover
 
     def setShutterOpen(self, *args):
         super().setShutterOpen(*args)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -659,6 +659,10 @@ class CMMCorePlus(pymmcore.CMMCore):
         img = super().getImage(*args)
         return self._fix_image(img) if fix else img
 
+    def setAutoShutter(self, state: bool):
+        super().setAutoShutter(state)
+        self.events.autoShutterSet.emit(state)
+
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""
         # approx retrieval cost in comment (for demoCam)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -669,7 +669,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     @overload
     def setShutterOpen(self, shutterLabel: str, state: bool) -> str:
-        ...
+        ... # pragma: no cover
 
     def setShutterOpen(self, *args):
         super().setShutterOpen(*args)

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -35,3 +35,4 @@ class PCoreSignaler(Protocol):
     # added for CMMCorePlus
     imageSnapped: PSignalInstance
     mdaEngineRegistered: PSignalInstance
+    autoShutterSet: PSignalInstance

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -36,3 +36,4 @@ class PCoreSignaler(Protocol):
     imageSnapped: PSignalInstance
     mdaEngineRegistered: PSignalInstance
     autoShutterSet: PSignalInstance
+    shutterSet: PSignalInstance

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -25,6 +25,7 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     # added for CMMCorePlus
     imageSnapped = Signal(np.ndarray)  # whenever snap is called
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
+    autoShutterSet = Signal(bool)
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -26,6 +26,7 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     imageSnapped = Signal(np.ndarray)  # whenever snap is called
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
     autoShutterSet = Signal(bool)
+    shutterSet = Signal(str, bool)
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -27,6 +27,7 @@ class QCoreSignaler(QObject):
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
     autoShutterSet = Signal(bool)
+    shutterSet = Signal(str, bool)
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -26,6 +26,7 @@ class QCoreSignaler(QObject):
     # added for CMMCorePlus
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
+    autoShutterSet = Signal(bool)
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:


### PR DESCRIPTION
This PR:

- adds a signal when the micromanager `autoshutter` state is changed
  autoShutterSet = Signal(bool)

- add a signal when the selected shutter state is changed
   shutterSet = Signal(shutter: str, bool)

used in https://github.com/tlambert03/napari-micromanager/pull/161