### PR TITLE
update setShutterOpen() method

### DIFF
--- a/pymmcore_plus/_tests/test_events.py
+++ b/pymmcore_plus/_tests/test_events.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, call
 import pytest
 from pymmcore import g_Keyword_Label as LABEL
 from pymmcore import g_Keyword_State as STATE
+from yaml import emit
 
 from pymmcore_plus import CMMCorePlus
 from pymmcore_plus.core.events import CMMCoreSignaler, PCoreSignaler, QCoreSignaler
@@ -176,14 +177,15 @@ def test_sequence_acquisition_events(core: CMMCorePlus):
 
 def test_shutter_device_events(core: CMMCorePlus):
     mock = Mock()
-    core.events.shutterSet.connect(mock)
+    core.events.propertyChanged.connect(mock)
     core.setShutterOpen("Shutter", True)
     mock.assert_has_calls(
         [
-            call("Shutter", True),
+            call("Shutter", STATE, True),
         ]
     )
     assert core.getShutterOpen("Shutter")
+    assert core.getProperty("Shutter", STATE) == "1"
 
 
 def test_autoshutter_device_events(core: CMMCorePlus):

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import atexit
 import os
 import re
-from tkinter.messagebox import NO
 import weakref
 from contextlib import contextmanager
 from datetime import datetime

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import os
 import re
+from tkinter.messagebox import NO
 import weakref
 from contextlib import contextmanager
 from datetime import datetime
@@ -708,11 +709,11 @@ class CMMCorePlus(pymmcore.CMMCore):
         self.events.autoShutterSet.emit(state)
 
     @overload
-    def setShutterOpen(self, state: bool) -> int:
+    def setShutterOpen(self, state: bool) -> None:
         ...  # pragma: no cover
 
     @overload
-    def setShutterOpen(self, shutterLabel: str, state: bool) -> str:
+    def setShutterOpen(self, shutterLabel: str, state: bool) -> None:
         ...  # pragma: no cover
 
     def setShutterOpen(self, *args):
@@ -722,7 +723,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         else:
             shutterLabel = super().getShutterDevice()
             state = args
-        self.events.shutterSet.emit(shutterLabel, state)
+        self.events.propertyChanged.emit(shutterLabel, "State", state)
 
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -39,4 +39,3 @@ class PCoreSignaler(Protocol):
     startSequenceAcquisition: PSignalInstance
     stopSequenceAcquisition: PSignalInstance
     autoShutterSet: PSignalInstance
-    shutterSet: PSignalInstance

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -29,7 +29,6 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     startSequenceAcquisition = Signal(str, int, float, bool)
     stopSequenceAcquisition = Signal(str)
     autoShutterSet = Signal(bool)
-    shutterSet = Signal(str, bool)
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -33,7 +33,6 @@ class QCoreSignaler(QObject):
     # when (Continuous)SequenceAcquisition is stopped
     stopSequenceAcquisition = Signal(str)
     autoShutterSet = Signal(bool)
-    shutterSet = Signal(str, bool)
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:


### PR DESCRIPTION
minor change in the `setShutterOpen()` method:
 - fix annotations
 - use `propertyChanged()` event  instead of `shutterSet` event. 

This is used in https://github.com/tlambert03/napari-micromanager/pull/161.