### PR TITLE
Fix waiting for mda events

### DIFF
--- a/pymmcore_plus/_tests/test_mda.py
+++ b/pymmcore_plus/_tests/test_mda.py
@@ -1,0 +1,22 @@
+import time
+
+from useq import MDASequence
+
+from pymmcore_plus import CMMCorePlus
+
+
+def test_mda_waiting(core: CMMCorePlus):
+    seq = MDASequence(
+        channels=["Cy5"],
+        time_plan={"interval": 1.5, "loops": 2},
+        axis_order="tpcz",
+        stage_positions=[(222, 1, 1), (111, 0, 0)],
+    )
+    t0 = time.perf_counter()
+    core.run_mda(seq).join()
+    t1 = time.perf_counter()
+
+    # check that we actually waited
+    # could expand to check that the actual times between events is correct
+    # but this would catch a breakdown of not waiting at all
+    assert t1 - t0 >= 1.5

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -171,24 +171,24 @@ class MDAEngine(PMDAEngine):
             if self._check_canceled():
                 return True
 
-            if event.min_start_time:
-                go_at = event.min_start_time + self._paused_time
-                # We need to enter a loop here checking paused and canceled.
-                # otherwise you'll potentially wait a long time to cancel
-                to_go = go_at - (time.perf_counter() - self._t0)
-                while to_go > 0:
-                    while self._paused and not self._canceled:
-                        self._paused_time += 0.1  # fixme: be more precise
-                        to_go += 0.1
-                        time.sleep(0.1)
+        if event.min_start_time:
+            go_at = event.min_start_time + self._paused_time
+            # We need to enter a loop here checking paused and canceled.
+            # otherwise you'll potentially wait a long time to cancel
+            to_go = go_at - (time.perf_counter() - self._t0)
+            while to_go > 0:
+                while self._paused and not self._canceled:
+                    self._paused_time += 0.1  # fixme: be more precise
+                    to_go += 0.1
+                    time.sleep(0.1)
 
-                    if self._canceled:
-                        break
-                    if to_go > 0.5:
-                        time.sleep(0.5)
-                    else:
-                        time.sleep(to_go)
-                    to_go = go_at - (time.perf_counter() - self._t0)
+                if self._canceled:
+                    break
+                if to_go > 0.5:
+                    time.sleep(0.5)
+                else:
+                    time.sleep(to_go)
+                to_go = go_at - (time.perf_counter() - self._t0)
 
         # check canceled again in case it was canceled
         # during the waiting loop


### PR DESCRIPTION
yikes. The indentation got messed up at some point when playing with MDA stuff and resulted in us never actually waiting until the time of the next mda event, instead just immediately executing it.

New test fails without the fix.

@tlambert03 would you be open to me making a release after this merges? If so how to do, just push a new tag?