### PR TITLE
fix potential typererror if canceled while waiting

### DIFF
--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -77,7 +77,6 @@ class MDAEngine(PMDAEngine):
         """
         self._canceled = True
         self._paused_time = 0
-        self._t0 = None
 
     def toggle_pause(self):
         """


### PR DESCRIPTION
Hopefully fixes the intermittent failures we were seeing such as https://github.com/tlambert03/pymmcore-plus/runs/6394080408?check_suite_focus=true

I think that if `cancel()` was being called after the check for `_canceled` then we were ending up with this typeerror

https://github.com/tlambert03/pymmcore-plus/blob/9c5fb10c26895cfe69e639496781750666e2c7c4/pymmcore_plus/mda/_engine.py#L185-L191

but there's no need to set it to `None` so lets just not do that

```
 E               pytest.PytestUnhandledThreadExceptionWarning: Exception in thread Thread-3 (run)
E               
E               Traceback (most recent call last):
E                 File "/Users/runner/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
E                   self.run()
E                 File "/Users/runner/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/threading.py", line 946, in run
E                   self._target(*self._args, **self._kwargs)
E                 File "/Users/runner/work/pymmcore-plus/pymmcore-plus/pymmcore_plus/mda/_engine.py", line 255, in run
E                   cancelled = self._wait_until_event(event, sequence)
E                 File "/Users/runner/work/pymmcore-plus/pymmcore-plus/pymmcore_plus/mda/_engine.py", line 191, in _wait_until_event
E                   to_go = go_at - (time.perf_counter() - self._t0)
E               TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'

../../../hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning
```