### PR TITLE
fix: Make sure to set xy in mda even if they are 0

### DIFF
--- a/pymmcore_plus/_tests/test_mda.py
+++ b/pymmcore_plus/_tests/test_mda.py
@@ -1,6 +1,6 @@
 import time
 
-from useq import MDASequence
+from useq import MDAEvent, MDASequence
 
 from pymmcore_plus import CMMCorePlus
 
@@ -20,3 +20,20 @@ def test_mda_waiting(core: CMMCorePlus):
     # could expand to check that the actual times between events is correct
     # but this would catch a breakdown of not waiting at all
     assert t1 - t0 >= 1.5
+
+
+def test_setting_position(core: CMMCorePlus):
+    core.mda._running = True
+    event1 = MDAEvent(exposure=123, x_pos=123, y_pos=456, z_pos=1)
+    core.mda._prep_hardware(event1)
+    assert tuple(core.getXYPosition()) == (123, 456)
+    assert core.getPosition() == 1
+    assert core.getExposure() == 123
+
+    # check that we aren't check things like: if event.x_pos
+    # because then we will not set to zero
+    event2 = MDAEvent(exposure=321, x_pos=0, y_pos=0, z_pos=0)
+    core.mda._prep_hardware(event2)
+    assert tuple(core.getXYPosition()) == (0, 0)
+    assert core.getPosition() == 0
+    assert core.getExposure() == 321

--- a/pymmcore_plus/mda/_engine.py
+++ b/pymmcore_plus/mda/_engine.py
@@ -209,8 +209,8 @@ class MDAEngine(PMDAEngine):
         if not self._running:
             return
         if event.x_pos is not None or event.y_pos is not None:
-            x = event.x_pos or self._mmc.getXPosition()
-            y = event.y_pos or self._mmc.getYPosition()
+            x = event.x_pos if event.x_pos is not None else self._mmc.getXPosition()
+            y = event.y_pos if event.y_pos is not None else self._mmc.getYPosition()
             self._mmc.setXYPosition(x, y)
         if event.z_pos is not None:
             self._mmc.setZPosition(event.z_pos)


### PR DESCRIPTION
previously the check wasn't working correctly if one of x or y was zero, then they would be incorrectly left in the current position.